### PR TITLE
Create npm script for building css

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,8 +7,9 @@
   ],
   "main": "./dist/index.js",
   "scripts": {
+    "build:css": "gulp build",
     "test": "echo \"Error: no test specified\" && exit 1",
-    "prepublishOnly": "gulp build && npm run build",
+    "prepublishOnly": "npm run build:css && npm run build",
     "build": "babel ./index.js -d ./dist"
   },
   "repository": {


### PR DESCRIPTION
Just a separate script we can run to build css separately, instead of having to run `prepublishOnly`.

It's better than having to install gulp globally just for this, we can now run `npm run build:css` or `yarn build:css`.