### PR TITLE
Update In Loco colors

### DIFF
--- a/src/site/globals/site.variables
+++ b/src/site/globals/site.variables
@@ -27,8 +27,10 @@
 @pinkHover        : #EB0559;
 @pinkFocus        : #EB0559;
 
+@blue             : #3A72FB;
+@green            : #A7CC0E;
 
-@linkColor           : #3a72fb;
+@linkColor           : @blue;
 @linkHoverColor      : darken(saturate(@linkColor, 20), 15, relative);
 
 /*-------------------


### PR DESCRIPTION
Adicionei o azul e o verde da In Loco. Precisamos do azul pra o Engage, só aproveitei pra adicionar o verde também.

@FranciscoGileno tá ok atualizar aqui mesmo né? Vocês não estão usando esse azul default em lugar algum, imagino? E se tivesse, provavelmente seria melhor usar o azul da In Loco de todo jeito.