### PR TITLE
feat(dropdown): adjust box-shadow styles for dropdown component

### DIFF
--- a/src/site/modules/dropdown.variables
+++ b/src/site/modules/dropdown.variables
@@ -2,15 +2,22 @@
     User Variable Overrides
 *******************************/
 
-@selectionHoverBorderColor: @borderHoverColor;
-@selectionHoverBoxShadow: inset 0 0 0 2px @shadowHoverColor;
+@borderColor:rgba(62,73,101,.25);
+
+@selectionHoverBorderColor: @borderColor;
+@selectionHoverBoxShadow: inset 0 0 0 1px rgba(99, 115, 129, .2);
 
 @selectionFocusBorderColor: @borderColor;
 @selectionFocusBoxShadow: 0 0 0 1px @shadowFocusColor;
 
+@selectionVisibleBorderColor: @borderColor;
 @selectionVisibleConnectingBorder: @borderRadius;
+@selectionVisibleBoxShadow: 0 0 0px 1px rgba(62, 73, 101, .5);
 
-@selectionMenuBoxShadow: 0 0 0 1px rgba(227, 228, 229, 0.45);
+@selectionActiveHoverBorderColor: @borderColor;
+@selectionActiveHoverBoxShadow: 0 0 0px 1px rgba(62, 73, 101, .5);
+
+@selectionMenuBoxShadow: 0 0 0 1px rgba(227, 228, 229, 0.45), 0 4px 6px 0 rgba(62, 73, 101, 0.16);
 @selectionVisibleMenuBoxShadow: @selectionMenuBoxShadow;
 @selectionFocusMenuBoxShadow: @selectionMenuBoxShadow;
 @selectionActiveHoverMenuBoxShadow: @selectionMenuBoxShadow;

--- a/src/site/modules/dropdown.variables
+++ b/src/site/modules/dropdown.variables
@@ -12,10 +12,10 @@
 
 @selectionVisibleBorderColor: @borderColor;
 @selectionVisibleConnectingBorder: @borderRadius;
-@selectionVisibleBoxShadow: 0 0 0px 1px rgba(62, 73, 101, .5);
+@selectionVisibleBoxShadow: 0 0 0px 1px fade(@n600, 5%);
 
 @selectionActiveHoverBorderColor: @borderColor;
-@selectionActiveHoverBoxShadow: 0 0 0px 1px rgba(62, 73, 101, .5);
+@selectionActiveHoverBoxShadow: 0 0 0px 1px fade(@n600, 5%);
 
 @selectionMenuBoxShadow: 0 0 0 1px rgba(227, 228, 229, 0.45), 0 4px 6px 0 rgba(62, 73, 101, 0.16);
 @selectionVisibleMenuBoxShadow: @selectionMenuBoxShadow;


### PR DESCRIPTION
Adjusting the shadows on dropdown component to follow the style defined by the designers. 

The prototype on Invision has some distorted/hard-to-find values. So our UI designer provided me with a styled .html file that reproduces the appropriate visual behavior for a text input (similar style). I copied the the values from that file. The menu shadow value was still taken from the Invision prototype only.

#### Before:
![supernova-dropdown-then](https://user-images.githubusercontent.com/9112403/47032151-07973280-d148-11e8-95d8-7c2358478309.gif)

#### Now:
![supernova-dropdown-now](https://user-images.githubusercontent.com/9112403/47032157-0ebe4080-d148-11e8-8214-b6a66de49c07.gif)

