### PR TITLE
Style Menu component

### DIFF
--- a/src/site/collections/menu.overrides
+++ b/src/site/collections/menu.overrides
@@ -3,7 +3,7 @@
 *******************************/
 
 /*--------------
-    Both basic and secondary pointing Menu
+    Both basic and secondary pointing Menu components
 ---------------*/
 
 .ui.pointing.menu {
@@ -60,7 +60,7 @@
 }
 
 /*--------------
-    Basic pointing Menu only
+    Basic pointing Menu component only
 ---------------*/
 
 .ui.pointing.menu:not(.secondary) > .item {
@@ -94,7 +94,7 @@
 }
 
 /*--------------
-    Secondary pointing Menu only
+    Secondary pointing Menu component only
 ---------------*/
 
 .ui.secondary.pointing.menu .item {

--- a/src/site/collections/menu.overrides
+++ b/src/site/collections/menu.overrides
@@ -2,8 +2,17 @@
          Site Overrides
 *******************************/
 
+/*--------------
+    Both basic and secondary pointing Menu
+---------------*/
+
 .ui.pointing.menu {
   margin: 0;
+  border: 0;
+  border-bottom: 2px solid @gray100;
+  border-radius: 0px;
+  background-color: transparent;
+  box-shadow: none;
 }
 
 .ui.pointing.menu .item,
@@ -11,6 +20,10 @@
   line-height: 20px;
   font-size: 14px;
   align-self: flex-start;
+}
+
+.ui.pointing.menu .active.item {
+  color: @n600;
 }
 
 .ui.pointing.menu .active.item:after,
@@ -25,14 +38,7 @@
   transform: translateY(-1px) translateX(-50%);
 }
 
-.ui.secondary.pointing.menu .item {
-  border: none;
-}
-
-.ui.pointing.menu .active.item {
-  color: @n600;
-}
-
+/* Colors */
 .ui.pointing.menu .active.item:after,
 .ui.pointing.menu .active.item:hover:after {
   background-color: @n600;
@@ -51,4 +57,46 @@
 .ui.pointing.green.menu .active.item:after,
 .ui.pointing.green.menu .active.item:hover:after {
   background-color: @green;
+}
+
+/*--------------
+    Basic pointing Menu only
+---------------*/
+
+.ui.pointing.menu:not(.secondary) > .item {
+  background-color: @gray30;
+}
+
+.ui.pointing.menu:not(.secondary) > .active.item {
+  background-color: @n0;
+  border-radius: 3px 3px 0 0;
+  border-style: solid;
+  border-color: @gray100 !important;
+  border-width: 1px 1px 0px;
+  padding: 7px 31px 8px;
+}
+
+.ui.pointing.menu > .item:not(.active):hover {
+  color: @gray700;
+  background-color: @gray50;
+}
+
+.ui.pointing.menu > .item {
+  border-radius: 0px;
+}
+
+.ui.pointing.menu > .item:first-child {
+  border-top-left-radius: 4px;
+}
+
+.ui.pointing.menu > .item:last-child {
+  border-top-right-radius: 4px;
+}
+
+/*--------------
+    Secondary pointing Menu only
+---------------*/
+
+.ui.secondary.pointing.menu .item {
+  border: none;
 }

--- a/src/site/collections/menu.overrides
+++ b/src/site/collections/menu.overrides
@@ -1,3 +1,54 @@
 /*******************************
          Site Overrides
 *******************************/
+
+.ui.pointing.menu {
+  margin: 0;
+}
+
+.ui.pointing.menu .item,
+.ui.secondary.pointing.menu .item {
+  line-height: 20px;
+  font-size: 14px;
+  align-self: flex-start;
+}
+
+.ui.pointing.menu .active.item:after,
+.ui.secondary.pointing.menu .active.item:after {
+  display: block;
+  content: " ";
+  width: 47px;
+  height: 4px;
+  border-radius: 3px;
+  border: none;
+  margin: 0;
+  transform: translateY(-1px) translateX(-50%);
+}
+
+.ui.secondary.pointing.menu .item {
+  border: none;
+}
+
+.ui.pointing.menu .active.item {
+  color: @n600;
+}
+
+.ui.pointing.menu .active.item:after,
+.ui.pointing.menu .active.item:hover:after {
+  background-color: @n600;
+}
+
+.ui.pointing.blue.menu .active.item:after,
+.ui.pointing.blue.menu .active.item:hover:after {
+  background-color: @blue;
+}
+
+.ui.pointing.pink.menu .active.item:after,
+.ui.pointing.pink.menu .active.item:hover:after {
+  background-color: @pink;
+}
+
+.ui.pointing.green.menu .active.item:after,
+.ui.pointing.green.menu .active.item:hover:after {
+  background-color: @green;
+}

--- a/src/site/collections/menu.variables
+++ b/src/site/collections/menu.variables
@@ -1,3 +1,15 @@
 /*******************************
     User Variable Overrides
 *******************************/
+
+@minHeight: 38px;
+@itemTextColor: @gray600;
+@itemFontWeight: 500;
+@activeItemFontWeight: @itemFontWeight;
+
+@secondaryPointingActiveFontWeight: @itemFontWeight;
+@secondaryPointingItemVerticalPadding: 8px;
+@secondaryPointingItemHorizontalPadding: 32px;
+@secondaryPointingBorderColor: @gray100;
+@secondaryPointingHoverTextColor: @itemTextColor;
+@secondaryPointingActiveTextColor: @n600;

--- a/src/site/collections/menu.variables
+++ b/src/site/collections/menu.variables
@@ -7,6 +7,9 @@
 @itemFontWeight: 500;
 @activeItemFontWeight: @itemFontWeight;
 
+@itemVerticalPadding: 8px;
+@itemHorizontalPadding: 32px;
+
 @secondaryPointingActiveFontWeight: @itemFontWeight;
 @secondaryPointingItemVerticalPadding: 8px;
 @secondaryPointingItemHorizontalPadding: 32px;

--- a/stories/Menu/index.stories.js
+++ b/stories/Menu/index.stories.js
@@ -4,13 +4,13 @@ import { storiesOf } from "@storybook/react";
 
 const items = [
   {
-    name: "TAB 1"
+    content: "TAB #1"
   },
   {
-    name: "TAB 2"
+    content: "TAB #2"
   },
   {
-    name: "TAB 3"
+    content: "TAB #3"
   }
 ];
 

--- a/stories/Menu/index.stories.js
+++ b/stories/Menu/index.stories.js
@@ -1,0 +1,37 @@
+import React from "react";
+import { Menu } from "semantic-ui-react";
+import { storiesOf } from "@storybook/react";
+
+const items = [
+  {
+    name: "TAB 1"
+  },
+  {
+    name: "TAB 2"
+  },
+  {
+    name: "TAB 3"
+  }
+];
+
+storiesOf("Menu", module)
+  .add("basic pointing ", () => <Menu pointing items={items} />)
+  .add("secondary pointing ", () => <Menu secondary pointing items={items} />)
+  .add("basic pointing blue", () => (
+    <Menu color="blue" pointing items={items} />
+  ))
+  .add("secondary pointing blue", () => (
+    <Menu secondary pointing color="blue" items={items} />
+  ))
+  .add("basic pointing pink", () => (
+    <Menu pointing color="pink" items={items} />
+  ))
+  .add("secondary pointing  pink", () => (
+    <Menu secondary pointing color="pink" items={items} />
+  ))
+  .add("basic pointing green", () => (
+    <Menu color="green" pointing items={items} />
+  ))
+  .add("secondary pointing green", () => (
+    <Menu secondary pointing color="green" items={items} />
+  ));


### PR DESCRIPTION
I've added the styles for the Menu component. Our UI Library refers to this component as `Tab`, though the actual `Tab` component only uses this `Menu`. Therefore, when using the `Tab` component with the proper Menu variation, we'll have theses styles as well.

I've overriden the `pointing` variation of the component, since we do have a "pointing" component (the little colored bar). The `secondary pointing` is the one we used to have as our previous `Tab` style (see [Secondary Pointing Menu](https://react.semantic-ui.com/collections/menu/#types-secondary-pointing)).

As always we can define our colors for the component, but as an extra I've also adjusted the 'colorless' style to use our Neutral color (N600) as default, instead of the ugly semantic black&gray.

#### Before:
![supernova-menu-then](https://user-images.githubusercontent.com/9112403/47296164-cf7c6d80-d5e7-11e8-86c5-c2da3282adaf.gif)

#### Now:
![supernova-menu-now](https://user-images.githubusercontent.com/9112403/47296286-2b46f680-d5e8-11e8-97c0-cc1990e2e154.gif)
