### PR TITLE
Update grayscale colors

### DIFF
--- a/src/site/collections/menu.overrides
+++ b/src/site/collections/menu.overrides
@@ -9,7 +9,7 @@
 .ui.pointing.menu {
   margin: 0;
   border: 0;
-  border-bottom: 2px solid @gray100;
+  border-bottom: 2px solid @gray300;
   border-radius: 0px;
   background-color: transparent;
   box-shadow: none;
@@ -64,21 +64,21 @@
 ---------------*/
 
 .ui.pointing.menu:not(.secondary) > .item {
-  background-color: @gray30;
+  background-color: @gray100;
 }
 
 .ui.pointing.menu:not(.secondary) > .active.item {
-  background-color: @n0;
+  background-color: @gray00;
   border-radius: 3px 3px 0 0;
   border-style: solid;
-  border-color: @gray100 !important;
+  border-color: @gray300 !important;
   border-width: 1px 1px 0px;
   padding: 7px 31px 8px;
 }
 
 .ui.pointing.menu > .item:not(.active):hover {
-  color: @gray700;
-  background-color: @gray50;
+  color: @gray900;
+  background-color: @gray200;
 }
 
 .ui.pointing.menu > .item {

--- a/src/site/collections/menu.variables
+++ b/src/site/collections/menu.variables
@@ -13,6 +13,6 @@
 @secondaryPointingActiveFontWeight: @itemFontWeight;
 @secondaryPointingItemVerticalPadding: 8px;
 @secondaryPointingItemHorizontalPadding: 32px;
-@secondaryPointingBorderColor: @gray300;
+@secondaryPointingBorderColor: fade(@n600, 15%);
 @secondaryPointingHoverTextColor: @itemTextColor;
 @secondaryPointingActiveTextColor: @n600;

--- a/src/site/collections/menu.variables
+++ b/src/site/collections/menu.variables
@@ -3,7 +3,7 @@
 *******************************/
 
 @minHeight: 38px;
-@itemTextColor: @gray600;
+@itemTextColor: @gray800;
 @itemFontWeight: 500;
 @activeItemFontWeight: @itemFontWeight;
 
@@ -13,6 +13,6 @@
 @secondaryPointingActiveFontWeight: @itemFontWeight;
 @secondaryPointingItemVerticalPadding: 8px;
 @secondaryPointingItemHorizontalPadding: 32px;
-@secondaryPointingBorderColor: @gray100;
+@secondaryPointingBorderColor: @gray300;
 @secondaryPointingHoverTextColor: @itemTextColor;
 @secondaryPointingActiveTextColor: @n600;

--- a/src/site/elements/input.overrides
+++ b/src/site/elements/input.overrides
@@ -3,5 +3,5 @@
 *******************************/
 
 .ui.icon.input > i.icon {
-  color: @gray400;
+  color: @gray600;
 }

--- a/src/site/elements/label.overrides
+++ b/src/site/elements/label.overrides
@@ -12,7 +12,7 @@
     padding: 0;
 
     > .removable-label-icon {
-      color: @gray400;
+      color: @gray600;
       cursor: pointer;
       height: 100%;
       padding: 0 2px;

--- a/src/site/globals/site.variables
+++ b/src/site/globals/site.variables
@@ -45,7 +45,6 @@
 @g400: #A7CC0E;
 @g500: #98B200;
 
-@n0: #FFFFFF;
 @n50: #F7F8F9;
 @n100: #E8EBED;
 @n200: #DCDFE3;
@@ -57,17 +56,18 @@
 // Equal to fade(@n600, 8%), but necessary due to stacking elements with opacity.
 @n600-hex-8: #F0F1F3;
 
-@gray10: #FAFBFC;
-@gray30: #F5F6F7;
-@gray50: #EEEFF0;
-@gray100: #E3E4E5;
-@gray200: #D7D8D9;
-@gray300: #BDBEBF;
-@gray400: #9E9FA0;
-@gray500: #757677;
-@gray600: #616263;
-@gray700: #4A4B4C;
-@gray800: #212223;
+@gray00: #FFFFFF;
+@gray50: #FAFBFC;
+@gray100: #F5F6F7;
+@gray200: #EEEFF0;
+@gray300: #E3E4E5;
+@gray400: #D7D8D9;
+@gray500: #BDBEBF;
+@gray600: #9E9FA0;
+@gray700: #757677;
+@gray800: #616263;
+@gray900: #4A4B4C;
+@gray1000: #212223;
 
 @pink             : @p400;
 @pinkHover        : #EB0559;

--- a/src/site/modules/dropdown.overrides
+++ b/src/site/modules/dropdown.overrides
@@ -11,7 +11,7 @@
 .ui.dropdown > .dropdown.icon:before {
   font-family: 'Icons';
   content: '\e5cf'; /* expand more */
-  color: @gray400;
+  color: @gray600;
 }
 
 .ui.loading.selection.dropdown>i.icon {

--- a/src/site/modules/progress.variables
+++ b/src/site/modules/progress.variables
@@ -2,5 +2,5 @@
     User Variable Overrides
 *******************************/
 
-@boxShadow: inset 0 0 1px @gray400;
+@boxShadow: inset 0 0 1px @gray600;
 @barMinWidth: 0;

--- a/src/site/views/card.variables
+++ b/src/site/views/card.variables
@@ -16,7 +16,7 @@
         Header
 --------------------*/
 
-@headerColor: @gray600;
+@headerColor: @gray800;
 @headerFontSize: 20px;
 @headerFontWeight: 300;
 
@@ -24,7 +24,7 @@
         Meta
 --------------------*/
 
-@metaColor: fade(@gray600, 88%);
+@metaColor: fade(@gray800, 88%);
 @metaFontSize: 12px;
 
 /*-------------------

--- a/src/site/views/item.variables
+++ b/src/site/views/item.variables
@@ -16,7 +16,7 @@
         Meta
 --------------------*/
 
-@metaColor: fade(@gray600, 88%);
+@metaColor: fade(@gray800, 88%);
 @metaFontSize: 12px;
 
 /*-------------------


### PR DESCRIPTION
Bruno answered about the naming for the grayscale colors. He sent me this screenshot with his name definitions:
![image](https://user-images.githubusercontent.com/9112403/47520104-a701a700-d865-11e8-94c4-a5faf1a11df5.png)

So I'm renaming the variables to the proper values.
Also, on the same conversation, he pointed out the correct value for the Menu border color, which I was setting as the current gray300. The correct one is N600 with .15 opacity.