### PR TITLE
Feature/input

### DIFF
--- a/src/site/elements/input.overrides
+++ b/src/site/elements/input.overrides
@@ -4,4 +4,23 @@
 
 .ui.icon.input > i.icon {
   color: @gray600;
+  font-size: 20px;
+}
+
+.ui.disabled.input > input,
+.ui.input:not(.disabled) input[disabled] {
+  background-color: @disabledBackgroundColor;
+}
+
+.ui.error.icon.input > i.icon {
+  color: @red;
+}
+
+.ui.input.warning > input {
+  color: @warningColor;
+  box-shadow: @warningBoxShadow;
+}
+
+.ui.warning.icon.input > i.icon {
+  color: @yellow;
 }

--- a/src/site/elements/input.variables
+++ b/src/site/elements/input.variables
@@ -5,27 +5,36 @@
 @iconOpacity: unset;
 @iconWidth: 41px;
 
+/*----------------------
+    Focus
+-----------------------*/
+
 @focusBorderColor: @borderColor;
 @focusBoxShadow: 0 0 0 1px @shadowFocusColor;
 @placeholderFocusColor: @placeholderColor;
-
 @downBoxShadow: @focusBoxShadow;
+
+/*----------------------
+    Disabled
+-----------------------*/
 
 @disabledOpacity: unset;
 @disabledBackgroundColor: fade(@n600, 8%);
 @disabledColor: fade(@textColor, 40%);
 
-@errorBackground: @gray00;
-@errorColor: @inputColor;
-@errorBoxShadow: 0 0 0 1px fade(@red, 50%);
-@placeholderErrorColor: @placeholderColor;
-@placeholderErrorFocusColor: @placeholderErrorColor;
+/*----------------------
+    Error
+-----------------------*/
 
 @errorBackground: @gray00;
 @errorColor: @inputColor;
 @errorBoxShadow: 0 0 0 1px fade(@red, 50%);
 @placeholderErrorColor: @placeholderColor;
 @placeholderErrorFocusColor: @placeholderErrorColor;
+
+/*----------------------
+    Warning
+-----------------------*/
 
 @warningColor: @inputColor;
 @warningBoxShadow: 0 0 0 1px fade(@yellow, 50%);

--- a/src/site/elements/input.variables
+++ b/src/site/elements/input.variables
@@ -3,3 +3,29 @@
 *******************************/
 
 @iconOpacity: unset;
+@iconWidth: 41px;
+
+@focusBorderColor: @borderColor;
+@focusBoxShadow: 0 0 0 1px @shadowFocusColor;
+@placeholderFocusColor: @placeholderColor;
+
+@downBoxShadow: @focusBoxShadow;
+
+@disabledOpacity: unset;
+@disabledBackgroundColor: fade(@n600, 8%);
+@disabledColor: fade(@textColor, 40%);
+
+@errorBackground: @gray00;
+@errorColor: @inputColor;
+@errorBoxShadow: 0 0 0 1px fade(@red, 50%);
+@placeholderErrorColor: @placeholderColor;
+@placeholderErrorFocusColor: @placeholderErrorColor;
+
+@errorBackground: @gray00;
+@errorColor: @inputColor;
+@errorBoxShadow: 0 0 0 1px fade(@red, 50%);
+@placeholderErrorColor: @placeholderColor;
+@placeholderErrorFocusColor: @placeholderErrorColor;
+
+@warningColor: @inputColor;
+@warningBoxShadow: 0 0 0 1px fade(@yellow, 50%);

--- a/src/site/globals/site.overrides
+++ b/src/site/globals/site.overrides
@@ -12,6 +12,6 @@
 .ui.form input[type=tel]:hover, .ui.form input[type=text]:hover,
 .ui.form input[type=time]:hover, .ui.form input[type=url]:hover,
 .ui.form textarea:hover {
-  border: 1px solid rgba(62, 73, 101, .35);
-  box-shadow: inset 0 0rem 0px 1px rgba(99, 115, 129, .2);
+  border: 1px solid @borderHoverColor;
+  box-shadow: inset 0 0rem 0px 1px @shadowHoverColor;
 }

--- a/src/site/globals/site.variables
+++ b/src/site/globals/site.variables
@@ -83,7 +83,8 @@
 @greenFocus       : #A2C204;
 @greenDown        : #98B200;
 
-@red: #D92400;
+@red        : #D92400;
+@yellow     : #FFAB00;
 
 @linkColor           : @blue;
 @linkHoverColor      : darken(saturate(@linkColor, 20), 15, relative);

--- a/src/site/modules/dropdown.overrides
+++ b/src/site/modules/dropdown.overrides
@@ -1,6 +1,7 @@
 /*******************************
         User Overrides
 *******************************/
+
 .ui.selection.dropdown > .search.icon,
 .ui.selection.dropdown > .delete.icon,
 .ui.selection.dropdown > .dropdown.icon {
@@ -33,4 +34,24 @@
 
 .ui.disabled.dropdown > .text {
   color: @disabledColor;
+}
+
+.ui.dropdown.error > .default.text {
+  color: @defaultTextColor;
+}
+
+.ui.dropdown.error,
+.ui.dropdown.error:hover,
+.ui.dropdown.error.active,
+.ui.dropdown.error.active:hover,
+.ui.dropdown.error:focus {
+  box-shadow: @errorBoxShadow;
+}
+
+.ui.dropdown.warning,
+.ui.dropdown.warning:hover,
+.ui.dropdown.warning.active,
+.ui.dropdown.warning.active:hover,
+.ui.dropdown.warning:focus {
+  box-shadow: @warningBoxShadow;
 }

--- a/src/site/modules/dropdown.variables
+++ b/src/site/modules/dropdown.variables
@@ -2,31 +2,48 @@
     User Variable Overrides
 *******************************/
 
+/*----------------------
+    Input
+-----------------------*/
+
 @borderRadius: 3px;
 @borderColor: fade(@n600, 25%);
 @textCursorSpacing: 0;
+@selectionIconOpacity: unset;
+@selectionIconVerticalPadding: 6px;
+@selectionIconHorizontalPadding: 12px;
+
+@selectionHoverBorderColor: @borderHoverColor;
+@selectionHoverBoxShadow: @shadowHover;
+@selectionFocusBorderColor: @selectionHoverBorderColor;
+@selectionFocusBoxShadow: 0 0 0 1px @shadowFocusColor;
+@selectionVisibleBorderColor: @borderColor;
+@selectionVisibleConnectingBorder: @borderRadius;
+@selectionVisibleBoxShadow: 0 0 0px 1px fade(@n600, 5%);
+@selectionActiveBoxShadow: 0 0 0 1px fade(@n600, 50%);
+@selectionActiveHoverBorderColor: @borderColor;
+@selectionActiveHoverBoxShadow: @selectionActiveBoxShadow;
+
+/*----------------------
+    Disabled Input
+-----------------------*/
+
+@disabledOpacity: unset;
+@disabledBackgroundColor: fade(@n600, 8%);
+@disabledColor: fade(@textColor, 40%);
+
+/*----------------------
+    Items
+-----------------------*/
 
 @itemDivider: none; 
 @selectionItemDivider: @itemDivider;
 @itemPadding: 10px 12px;
 @selectionItemPadding: @itemPadding;
 
-@selectionIconOpacity: unset;
-
-@selectionHoverBorderColor: @borderHoverColor;
-@selectionHoverBoxShadow: @shadowHover;
-
-@selectionFocusBorderColor: @selectionHoverBorderColor;
-@selectionFocusBoxShadow: 0 0 0 1px @shadowFocusColor;
-
-@selectionVisibleBorderColor: @borderColor;
-@selectionVisibleConnectingBorder: @borderRadius;
-@selectionVisibleBoxShadow: 0 0 0px 1px fade(@n600, 5%);
-
-@selectionActiveBoxShadow: 0 0 0 1px fade(@n600, 50%);
-
-@selectionActiveHoverBorderColor: @borderColor;
-@selectionActiveHoverBoxShadow: @selectionActiveBoxShadow;
+/*----------------------
+    Selection Menu
+-----------------------*/
 
 @selectionMenuBoxShadow: 0 0 0 1px rgba(227, 228, 229, 0.45), 0 4px 6px 0 fade(@n600, 16%);
 @selectionVisibleMenuBoxShadow: @selectionMenuBoxShadow;
@@ -36,7 +53,23 @@
 @menuBorder: none;
 @menuBorderWidth: 0px;
 
-@disabledOpacity: unset;
+/*----------------------
+    Error
+-----------------------*/
 
-@disabledBackgroundColor: fade(@n600, 8%);
-@disabledColor: fade(@textColor, 40%);
+@errorBackgroundColor: @gray00;
+@errorTextColor: @textColor;
+@errorBorderColor: @borderColor;
+@errorBoxShadow: 0 0 0 1px fade(@red, 50%);
+@errorIconColor: @red;
+
+@errorItemTextColor: @itemColor;
+@errorItemHoverBackground: @hoveredItemBackground;
+@errorItemActiveBackground: @selectedBackground;
+
+/*----------------------
+    Warning
+-----------------------*/
+
+@warningBoxShadow: 0 0 0 1px fade(@yellow, 50%);
+@warningIconColor: @yellow;

--- a/stories/Dropdown/index.stories.js
+++ b/stories/Dropdown/index.stories.js
@@ -12,6 +12,12 @@ storiesOf('Dropdown', module)
   .add('selection', () => (
     <Dropdown placeholder="Select Friend" selection options={friendOptions} />
   ))
+  .add('selection error', () => (
+    <Dropdown placeholder="Select Friend" selection error options={friendOptions} />
+  ))
+  .add('selection warning', () => (
+    <Dropdown placeholder="Select Friend" selection className='warning' options={friendOptions} />
+  ))
   .add('search', () => (
     <Dropdown placeholder="Select Friend" selection search options={friendOptions} />
   ))

--- a/stories/Input/index.stories.js
+++ b/stories/Input/index.stories.js
@@ -1,0 +1,14 @@
+import React from "react"
+import { storiesOf } from "@storybook/react"
+
+import { Input } from "../../components"
+
+storiesOf("Input", module)
+  .add("selection", () => <Input placeholder="Input..." />)
+  .add("disabled", () => <Input placeholder="Input..." disabled />)
+  .add("error icon", () => (
+    <Input placeholder="Input..." error icon="error" />
+  ))
+  .add("warning icon", () => (
+    <Input placeholder="Input..." className="warning" icon="warning" />
+  ))


### PR DESCRIPTION
Applying styles for the `Input` component and for the "error" and "disabled" `Dropdown` component. 
I followed the prototype for the `Input` component, but there were no specifications for the error and disabled `Dropdown` component. So I just assumed it should look just like the `Input`, since all the other aspects are the same.

### Input
##### BEFORE
![supernova-input](https://user-images.githubusercontent.com/9112403/47565575-50e14200-d8ff-11e8-9a3e-97f2a75bd3cd.gif)

##### NOW
![supernova-input-now](https://user-images.githubusercontent.com/9112403/47565576-52126f00-d8ff-11e8-96d6-7262dc5dd188.gif)


### Dropdown
##### BEFORE
![supernova-dropdown-error-then](https://user-images.githubusercontent.com/9112403/47565582-5a6aaa00-d8ff-11e8-9b36-e0498c6f3d90.gif)

##### NOW
![supernova-dropdown-error-now](https://user-images.githubusercontent.com/9112403/47565583-5ccd0400-d8ff-11e8-988e-fc32f46d740a.gif)
