### PR TITLE
Docs: Add css build and watch commands

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ To setup the project, you just need to have [Yarn](https://yarnpkg.com/en/) inst
 ```sh
   yarn
 ```
+Then we run the command below to update css with our customizations:
 
 ```sh
   yarn run build:css

--- a/README.md
+++ b/README.md
@@ -20,6 +20,18 @@ To setup the project, you just need to have [Yarn](https://yarnpkg.com/en/) inst
   yarn
 ```
 
+```sh
+  yarn run build:css
+```
+
+### Watch (Hot reloading)
+
+To update css on file change:
+
+```sh
+  yarn run watch:css
+```
+
 ### Storybook
 
 We're using [Storybook](https://storybook.js.org/), to easily see and test the components.


### PR DESCRIPTION
I followed the readme and after `yarn` command I run `yarn storybook` which opened storybook without our customizations.

We had to build the css first to see them applied on storybook.