### PR TITLE
Style Icon Buttons

### DIFF
--- a/src/site/elements/button.overrides
+++ b/src/site/elements/button.overrides
@@ -67,3 +67,16 @@
 .ui.outline.green.button {
   .outlineButton(@green, @g50, @g100, @g500)
 }
+
+.ui.icon.button {
+  min-width: @iconWidth;
+  min-height: @iconHeight;
+
+  &.outline > .icon:not(.button){
+    height: calc(@iconHeight - 2px);
+  }
+
+  .icon {
+    font-size: @iconFontSize;
+  }
+}

--- a/src/site/elements/button.overrides
+++ b/src/site/elements/button.overrides
@@ -3,7 +3,7 @@
 *******************************/
 
 .ui.button {
-  font-spacing: @fontSpacing;
+  letter-spacing: @fontSpacing;
 }
 
 .ui.secondary.button:hover {
@@ -35,8 +35,12 @@
 .outlineButton(@main, @hover, @activeLight, @activeDark) {
   background-color: #fff;
   border: 1px solid @main;
+  line-height: calc(@lineHeight - 2px);
   color: @main;
 
+  &:not(.icon) {
+    padding: @verticalPadding calc(@horizontalPadding - 1px);
+  }
   &:hover,
   &:focus {
     background-color: @hover;

--- a/src/site/elements/button.variables
+++ b/src/site/elements/button.variables
@@ -37,3 +37,8 @@
 @basicHoverBackground: rgba(62,73,101,0.08);
 @basicFocusBackground: rgba(62,73,101,0.08);
 @basicDownBackground: rgba(62,73,101,0.12);
+
+@iconButtonOpacity: unset;
+@iconFontSize: 20px;
+@iconHeight: @lineHeight;
+@iconWidth: @iconHeight;

--- a/stories/Button/index.stories.js
+++ b/stories/Button/index.stories.js
@@ -19,6 +19,21 @@ storiesOf('Button', module)
         <Button disabled className="green" onClick={action('clicked green')}>Green Disabled</Button>
       </React.Fragment>
   ))
+  .add('primary icon', () => (
+    <React.Fragment>
+      <Button className="blue" onClick={action('clicked blue')} icon='cloud'/>
+      <br/><br/>
+      <Button className="pink" onClick={action('clicked pink')} icon='cloud'/>
+      <br/><br/>
+      <Button className="green" onClick={action('clicked green')} icon='cloud'/>
+      <br/><br/>
+      <Button disabled className="blue" onClick={action('clicked blue')} icon='cloud'/>
+      <br/><br/>
+      <Button disabled className="pink" onClick={action('clicked pink')} icon='cloud'/>
+      <br/><br/>
+      <Button disabled className="green" onClick={action('clicked green')} icon='cloud'/>
+    </React.Fragment>
+  ))
   .add('subtle', () => (
       <React.Fragment>
         <Button basic className="blue" onClick={action('clicked blue')}>Blue</Button>
@@ -47,6 +62,21 @@ storiesOf('Button', module)
         <Button disabled className="outline pink" onClick={action('clicked pink')}>Pink Disabled</Button>
         <br/><br/>
         <Button disabled className="outline green" onClick={action('clicked green')}>Green Disabled</Button>
+      </React.Fragment>
+  ))
+  .add('outline icon', () => (
+      <React.Fragment>
+        <Button className="outline blue" onClick={action('clicked blue')} icon='cloud'/>
+        <br/><br/>
+        <Button className="outline pink" onClick={action('clicked pink')} icon='cloud'/>
+        <br/><br/>
+        <Button className="outline green" onClick={action('clicked green')} icon='cloud'/>
+        <br/><br/>
+        <Button disabled className="outline blue" onClick={action('clicked blue')} icon='cloud'/>
+        <br/><br/>
+        <Button disabled className="outline pink" onClick={action('clicked pink')} icon='cloud'/>
+        <br/><br/>
+        <Button disabled className="outline green" onClick={action('clicked green')} icon='cloud'/>
       </React.Fragment>
   ))
   .add('loading', () => (


### PR DESCRIPTION
I'm adding the styles for the Icon-only buttons and fixing the height for the `outline` buttons. They were 2px taller and 2px wider because of their borders.

![supernova-icon-button](https://user-images.githubusercontent.com/9112403/47677869-0bdb3b00-db9f-11e8-962d-1e0d6f76f19e.gif)
