### PR TITLE
Fix dimensions and position of Message component

### DIFF
--- a/src/site/collections/message.overrides
+++ b/src/site/collections/message.overrides
@@ -2,6 +2,10 @@
         Site Overrides
 *******************************/
 
+.ui.message {
+  width: @width !important;
+}
+
 .ui.message p {
   line-height: @lineHeight;
 }
@@ -9,6 +13,12 @@
 .ui.message > .close.icon {
   font-size: @closeIconSize;
   color: @closeIconColor;
+}
+
+.ui.floating.message {
+  position: fixed;
+  top: @topDistance;
+  z-index: @floatingZIndex;
 }
 
 .ui.floating.negative.message {

--- a/src/site/collections/message.variables
+++ b/src/site/collections/message.variables
@@ -2,7 +2,11 @@
     User Variable Overrides
 *******************************/
 
+@width: 601px;
+@topDistance: 24px;
+
 @floatingBoxShadow: @z400BoxShadow; 
+@floatingZIndex: 400;
 
 @messageTextOpacity: unset;
 @headerFontSize: 14px;


### PR DESCRIPTION
The message was being dimensioned as a fluid component and positioned according to it's container, but Bruno [commented that](https://projects.invisionapp.com/d/main#/console/15350162/322623073/comments/106266133) it should have a fixed width and a fixed position, 24px away from the top. So I'm adding these changes. 

I just couldn't figure out how to position the component in the center, since [I think] it depends on the parent element to center. So we'll have to center the alert manually when we use this component. Any suggestion on how to fix that is welcome.