### PR TITLE
Position Message component at the center of the page

### DIFF
--- a/src/site/collections/message.overrides
+++ b/src/site/collections/message.overrides
@@ -17,6 +17,8 @@
 
 .ui.floating.message {
   position: fixed;
+  left: 50%;
+  margin-left: calc(-@width/2);
   top: @topDistance;
   z-index: @floatingZIndex;
 }


### PR DESCRIPTION
That fixes the position problem for the Message component 😄 
Since we're using `position: fixed`, the traditional `margin: auto` was not working. 
So I'm moving the Component 50% of its parent's width to the right, but since it's anchored on top-left, we also need to move it back 50% of its width back to the left. 

It's all good now (: 

![supernova-center-message](https://user-images.githubusercontent.com/9112403/48264658-0b496c80-e409-11e8-9ffb-c7e135502a37.gif)

