### PR TITLE
fix(checkbox): fix radio's style

### DIFF
--- a/src/site/modules/checkbox.overrides
+++ b/src/site/modules/checkbox.overrides
@@ -120,7 +120,7 @@
   .box:active,
   label:active {
       &::before {
-        background-color: @activeLight;
+        border: 1px solid @activeLight;
       }
   }
 
@@ -129,6 +129,7 @@
       & ~ .box,
       & ~ label {
         &:before {
+          background-color: transparent !important;
           border: 1px solid @main;
         }
 
@@ -148,7 +149,6 @@
 
         &:active {
           &::before {
-            background-color: @activeLight;
             border: 1px solid @activeDark;
           }
 

--- a/src/site/modules/checkbox.overrides
+++ b/src/site/modules/checkbox.overrides
@@ -120,7 +120,7 @@
   .box:active,
   label:active {
       &::before {
-        border: 1px solid @activeLight;
+        background-color: @activeLight;
       }
   }
 
@@ -149,6 +149,7 @@
 
         &:active {
           &::before {
+            background-color: @activeLight !important;
             border: 1px solid @activeDark;
           }
 

--- a/stories/Checkbox/index.stories.js
+++ b/stories/Checkbox/index.stories.js
@@ -6,25 +6,34 @@ storiesOf('Checkbox', module)
   .add('regular', () => (
     <React.Fragment>
       <Checkbox className="blue" label="Blue" defaultChecked />
-      <br/><br/>
+      <br /><br />
       <Checkbox className="pink" label="Pink" defaultChecked />
-      <br/><br/>
+      <br /><br />
       <Checkbox className="green" label="Green" defaultChecked />
     </React.Fragment>
   ))
   .add('indeterminate', () => (
     <React.Fragment>
       <Checkbox className="blue" label="Blue" defaultIndeterminate />
-      <br/><br/>
+      <br /><br />
       <Checkbox className="pink" label="Pink" defaultIndeterminate />
-      <br/><br/>
+      <br /><br />
       <Checkbox className="green" label="Green" defaultIndeterminate />
     </React.Fragment>
   ))
   .add('disabled', () => (
     <React.Fragment>
       <Checkbox label="Checked disabled" disabled defaultChecked />
-      <br/><br/>
+      <br /><br />
       <Checkbox label="Unchecked disabled" disabled />
+    </React.Fragment>
+  ))
+  .add('radio', () => (
+    <React.Fragment>
+      <Checkbox className="blue" label="Radio Blue" radio />
+      <br /><br />
+      <Checkbox className="pink" label="Radio Pink" radio />
+      <br /><br />
+      <Checkbox className="green" label="Radio Green" radio />
     </React.Fragment>
   ))


### PR DESCRIPTION
Anteriormente ficava apenas o círculo completamente preenchido com a cor principal.

![area-potential](https://user-images.githubusercontent.com/4473734/48620529-325eeb80-e97f-11e8-9db4-9f0ce458c78f.gif)
