### PR TITLE
fix(removable-label): apply the onClick to the area that contains the icon

### DIFF
--- a/components/RemovableLabel/index.js
+++ b/components/RemovableLabel/index.js
@@ -5,8 +5,8 @@ export const RemovableLabel = props => {
   const { children, className = '', content, onRemove, ...otherProps } = props
   return (
     <Label className={`removable ${className}`} {...otherProps}>
-      <div className="removable-label-icon">
-        <Icon className="clear" size="big" onClick={onRemove} />
+      <div className="removable-label-icon" onClick={onRemove}>
+        <Icon className="clear" size="big" />
       </div>
       <span className="removable-label-content">{children || content}</span>
     </Label>


### PR DESCRIPTION
Anteriormente o click só era percebido se fosse feito diretamente em cima do ícone, agora ele é percebido se a área onde o ícone está contido for clicada.

![screen shot 2018-11-16 at 2 00 35 pm](https://user-images.githubusercontent.com/4473734/48635847-0d32a300-e9a8-11e8-893f-d654384a95e3.png)
