### PR TITLE
Hiding overflow for cards

### DIFF
--- a/src/site/views/card.overrides
+++ b/src/site/views/card.overrides
@@ -1,3 +1,7 @@
 /*******************************
     User Variable Overrides
 *******************************/
+
+.ui.card {
+  overflow: hidden;
+}


### PR DESCRIPTION
The combination of shadow-box with border-radius that we're using for our cards causes some weird problems when a child of the card has background-color. The most recent I've had was with the lower left border having a little white glitch.

Take a look:
<img width="36" alt="screen shot 2018-11-20 at 11 52 28 am" src="https://user-images.githubusercontent.com/5216049/48782363-cc46d100-ecbc-11e8-8ab3-2acc340da061.png">

This can be fixed with `overflow: hidden`, but since it's so common (and it took me a whihle to investigate as well) it's best to have that fixed here, so no one else falls into this again.