### PR TITLE
Add more padding for the toggle checkbox's label

### DIFF
--- a/src/site/modules/checkbox.variables
+++ b/src/site/modules/checkbox.variables
@@ -25,6 +25,7 @@
 *******************************/
 
 @toggleLabelOffset: 0;
+@toggleLabelDistance: 40px;
 
 /*******************************
             Toggle Lane


### PR DESCRIPTION
**Antes**
<img width="98" alt="screen shot 2018-11-28 at 9 27 49 am" src="https://user-images.githubusercontent.com/5216049/49151911-041ecb80-f2f0-11e8-80ee-6d37fcc75488.png">

**Depois**
<img width="109" alt="screen shot 2018-11-28 at 9 27 35 am" src="https://user-images.githubusercontent.com/5216049/49151918-084ae900-f2f0-11e8-84e6-b78a931393e9.png">
