### PR TITLE
Style the Dropdown header

### DIFF
--- a/src/site/modules/dropdown.overrides
+++ b/src/site/modules/dropdown.overrides
@@ -36,6 +36,10 @@
   color: @disabledColor;
 }
 
+.ui.dropdown .menu > .header {
+  background-color: @gray100;
+}
+
 .ui.dropdown.error > .default.text {
   color: @defaultTextColor;
 }

--- a/src/site/modules/dropdown.variables
+++ b/src/site/modules/dropdown.variables
@@ -54,6 +54,15 @@
 @menuBorderWidth: 0px;
 
 /*----------------------
+    Header
+-----------------------*/
+
+@menuHeaderColor: @gray800;
+@menuHeaderFontWeight: 400;
+@menuHeaderMargin: 0;
+@menuHeaderPadding: 12px;
+
+/*----------------------
     Error
 -----------------------*/
 

--- a/stories/Dropdown/index.stories.js
+++ b/stories/Dropdown/index.stories.js
@@ -24,3 +24,13 @@ storiesOf('Dropdown', module)
   .add('disabled', () => (
     <Dropdown placeholder="Select Friend" selection options={friendOptions} disabled />
   ))
+  .add('header', () => (
+    <Dropdown
+      placeholder="Select Friend"
+      selection
+      options={friendOptions}
+      header={<Dropdown.Header content="My Header" />}
+      selectOnBlur={false}
+      selectOnNavigation={false}
+    />
+  ))


### PR DESCRIPTION
We started using the dropdown header on Engage, so I'm moving the shared styles (basically just padding, background and font color) here.

**Before**
<img width="224" alt="screen shot 2018-11-29 at 9 38 54 am" src="https://user-images.githubusercontent.com/5216049/49222462-b4f19d00-f3ba-11e8-94b9-c089accbbfe6.png">


**After**
<img width="224" alt="screen shot 2018-11-29 at 9 38 35 am" src="https://user-images.githubusercontent.com/5216049/49222473-b91dba80-f3ba-11e8-9171-c15877f9083e.png">
