### PR TITLE
Change the selected toggle label color

### DIFF
--- a/src/site/modules/checkbox.variables
+++ b/src/site/modules/checkbox.variables
@@ -15,6 +15,7 @@
 @checkboxIndeterminateCheckColor: #fff;
 
 @labelDistance: 24px;
+@labelFocusColor: @textColor;
 
 @checkboxTransition:
   border 0.24s cubic-bezier(.64,0,.35,1),
@@ -26,6 +27,8 @@
 
 @toggleLabelOffset: 0;
 @toggleLabelDistance: 40px;
+@toggleOffLabelColor: @textColor;
+@toggleOnLabelColor: @textColor;
 
 /*******************************
             Toggle Lane


### PR DESCRIPTION
Semantic defines a different color for on/off states for this component, but we want both to use the default text color.

Same for when the label is focused.