### PR TITLE
Style vertical inline sub menu

### DIFF
--- a/src/site/collections/menu.overrides
+++ b/src/site/collections/menu.overrides
@@ -160,9 +160,11 @@
   border-radius: 3px;
   color: @textColor;
   display: flex;
+  flex-wrap: wrap;
   font-weight: 400;
+  line-height: 24px;
   margin-bottom: 8px;
-  padding: 12px;
+  padding: 12px 0;
 
   &:last-child {
     margin-bottom: 0;
@@ -186,19 +188,87 @@
 }
 
 .ui.vertical.menu .item > i.icon {
+  align-items: center;
   color: @gray600;
+  display: flex;
   font-size: 20px;
+  justify-content: center;
   margin-right: 8px;
+
+  &:first-child {
+    margin-left: 12px;
+  }
 }
 
-.ui.blue.vertical.menu .active.item > i.icon {
+.ui.blue.vertical.menu .active.item > i.icon:first-child,
+.ui.blue.vertical.menu .active.item .title > i.icon:first-child {
   color: @blue;
 }
 
-.ui.pink.vertical.menu .active.item > i.icon {
+.ui.pink.vertical.menu .active.item > i.icon:first-child,
+.ui.pink.vertical.menu .active.item .title > i.icon:first-child {
   color: @pink;
 }
 
-.ui.green.vertical.menu .active.item > i.icon {
+.ui.green.vertical.menu .active.item > i.icon:first-child,
+.ui.green.vertical.menu .active.item .title > i.icon:first-child {
   color: @green;
+}
+
+/*--------------
+    Vertical Accordion Menu
+---------------*/
+
+.ui.vertical.accordion.menu {
+  .item {
+    .title {
+      align-items: center;
+      display: flex;
+      height: 48px;
+      margin: -12px 0;
+      padding: 12px;
+      width: 100%;
+
+      &.active {
+        background-color: @n600-hex-4;
+
+        i.icon {
+          color: @gray600;
+        }
+      }
+
+      i.icon {
+        color: @gray600;
+        font-size: 20px;
+        height: @iconWidth;
+        margin-right: 8px;
+        width: @iconWidth;
+      }
+
+      i.icon:last-child {
+        margin: 0 -4px 0 auto;
+      }
+    }
+
+    .title ~ .menu.content {
+      background-color: @n600-hex-8;
+      margin: 12px 0 -12px;
+      padding: 8px 0;
+      width: 100%;
+
+      .item {
+        margin-bottom: 0;
+        padding: 8px 0;
+
+        &:hover {
+          background-color: @hoverItemBackground;
+        }
+
+        &.active {
+          background-color: @activeItemBackground;
+          font-weight: 400;
+        }
+      }
+    }
+  }
 }

--- a/src/site/collections/menu.overrides
+++ b/src/site/collections/menu.overrides
@@ -145,3 +145,59 @@
   height: 2px;
   transform: translateY(-5px) translateX(-50%);
 }
+
+/*--------------
+    Vertical Menu
+---------------*/
+
+.ui.vertical.menu {
+  border: none;
+  padding: 8px;
+}
+
+.ui.vertical.menu .item {
+  align-items: center;
+  border-radius: 3px;
+  color: @textColor;
+  display: flex;
+  font-weight: 400;
+  margin-bottom: 8px;
+  padding: 12px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+
+  &.active {
+    border-radius: 3px;
+  }
+
+  &.header {
+    color: fade(@gray800, 88%);
+    font-size: 12px;
+    opacity: 0.5;
+
+    &:hover {
+      background-color: @gray00;
+      cursor: default;
+    }
+  }
+}
+
+.ui.vertical.menu .item > i.icon {
+  color: @gray600;
+  font-size: 20px;
+  margin-right: 8px;
+}
+
+.ui.blue.vertical.menu .active.item > i.icon {
+  color: @blue;
+}
+
+.ui.pink.vertical.menu .active.item > i.icon {
+  color: @pink;
+}
+
+.ui.green.vertical.menu .active.item > i.icon {
+  color: @green;
+}

--- a/src/site/collections/menu.overrides
+++ b/src/site/collections/menu.overrides
@@ -170,6 +170,7 @@
 
   &.active {
     border-radius: 3px;
+    color: @textColor !important;
   }
 
   &.header {

--- a/src/site/collections/menu.variables
+++ b/src/site/collections/menu.variables
@@ -41,3 +41,6 @@
 
 @verticalIconFloat: none;
 @verticalIconMargin: 0;
+
+@subMenuFontSize: 14px;
+@subMenuTextColor: @textColor;

--- a/src/site/collections/menu.variables
+++ b/src/site/collections/menu.variables
@@ -4,11 +4,23 @@
 
 @minHeight: 38px;
 @itemTextColor: @gray800;
+@hoverItemTextColor: @textColor;
 @itemFontWeight: 500;
 @activeItemFontWeight: @itemFontWeight;
 
+@borderRadius: 3px;
+
 @itemVerticalPadding: 8px;
 @itemHorizontalPadding: 32px;
+
+@hoverItemBackground: fade(@n600, 4%);
+@activeHoverItemBackground: fade(@n600, 4%);
+
+@activeItemBackground: fade(@n600, 8%);
+
+@iconWidth: 24px;
+
+@headerWeight: 400;
 
 @secondaryPointingActiveFontWeight: @itemFontWeight;
 @secondaryPointingItemVerticalPadding: 8px;
@@ -20,3 +32,12 @@
 @secondaryPointingPaginationItemBackground: transparent;
 @secondaryPointingPaginationItemBackgroundHover: fade(@n600, 8%);
 @secondaryPointingPaginationItemBackgroundActive: fade(@n600, 12%);
+
+/*--------------
+    Vertical Menu
+---------------*/
+
+@verticalBoxShadow: 0 8px 10px 0 fade(@n600, 20%);
+
+@verticalIconFloat: none;
+@verticalIconMargin: 0;

--- a/src/site/globals/site.variables
+++ b/src/site/globals/site.variables
@@ -53,6 +53,8 @@
 @n500: #6E778C;
 @n600: #3E4965;
 
+// Equal to fade(@n600, 4%), but necessary due to stacking elements with opacity.
+@n600-hex-4: #F7F8F9;
 // Equal to fade(@n600, 8%), but necessary due to stacking elements with opacity.
 @n600-hex-8: #F0F1F3;
 

--- a/stories/Menu/index.stories.js
+++ b/stories/Menu/index.stories.js
@@ -1,37 +1,53 @@
-import React from "react";
-import { Menu } from "semantic-ui-react";
-import { storiesOf } from "@storybook/react";
+import React from 'react'
+import { Icon, Menu } from 'semantic-ui-react'
+import { storiesOf } from '@storybook/react'
 
 const items = [
   {
-    content: "TAB #1"
+    content: 'TAB #1'
   },
   {
-    content: "TAB #2"
+    content: 'TAB #2'
   },
   {
-    content: "TAB #3"
+    content: 'TAB #3'
   }
 ];
 
-storiesOf("Menu", module)
-  .add("basic pointing ", () => <Menu pointing items={items} />)
-  .add("secondary pointing ", () => <Menu secondary pointing items={items} />)
-  .add("basic pointing blue", () => (
+const verticalItems = [
+  {
+    content: 'Home',
+    icon: 'home'
+  },
+  {
+    content: 'Places',
+    icon: 'place'
+  },
+  {
+    content: 'Reports',
+    icon: 'assignment'
+  }
+]
+
+storiesOf('Menu', module)
+  .add('vertical', () => <Menu vertical items={verticalItems} />)
+  .add('basic pointing ', () => <Menu pointing items={items} />)
+  .add('secondary pointing ', () => <Menu secondary pointing items={items} />)
+  .add('basic pointing blue', () => (
     <Menu color="blue" pointing items={items} />
   ))
-  .add("secondary pointing blue", () => (
+  .add('secondary pointing blue', () => (
     <Menu secondary pointing color="blue" items={items} />
   ))
-  .add("basic pointing pink", () => (
+  .add('basic pointing pink', () => (
     <Menu pointing color="pink" items={items} />
   ))
-  .add("secondary pointing  pink", () => (
+  .add('secondary pointing  pink', () => (
     <Menu secondary pointing color="pink" items={items} />
   ))
-  .add("basic pointing green", () => (
+  .add('basic pointing green', () => (
     <Menu color="green" pointing items={items} />
   ))
-  .add("secondary pointing green", () => (
+  .add('secondary pointing green', () => (
     <Menu secondary pointing color="green" items={items} />
   ));

--- a/stories/Menu/index.stories.js
+++ b/stories/Menu/index.stories.js
@@ -14,23 +14,56 @@ const items = [
   }
 ];
 
-const verticalItems = [
-  {
-    content: 'Home',
-    icon: 'home'
-  },
-  {
-    content: 'Places',
-    icon: 'place'
-  },
-  {
-    content: 'Reports',
-    icon: 'assignment'
-  }
-]
-
 storiesOf('Menu', module)
-  .add('vertical', () => <Menu vertical items={verticalItems} />)
+  .add('vertical', () => {
+    const items = [
+      {
+        content: 'Header',
+        header: true
+      },
+      {
+        content: 'Home',
+        icon: 'home'
+      },
+      {
+        content: 'Places',
+        icon: 'place'
+      },
+      {
+        content: 'Reports',
+        icon: 'assignment'
+      }
+    ]
+    return (
+      <React.Fragment>
+        <Menu className="blue" vertical items={items} />
+        <Menu className="pink" vertical items={items} />
+        <Menu className="green" vertical items={items} />
+      </React.Fragment>
+    )
+  })
+  .add('vertical icons only', () => {
+    const items = [
+      {
+        icon: 'home'
+      },
+      {
+        icon: 'place'
+      },
+      {
+        icon: 'assignment'
+      }
+    ]
+    return (
+      <React.Fragment>
+        <Menu className="blue" vertical icon items={items} />
+        <br />
+        <Menu className="pink" vertical icon items={items} />
+        <br />
+        <Menu className="green" vertical icon items={items} />
+      </React.Fragment>
+    )
+  })
   .add('basic pointing ', () => <Menu pointing items={items} />)
   .add('secondary pointing ', () => <Menu secondary pointing items={items} />)
   .add('basic pointing blue', () => (

--- a/stories/Menu/index.stories.js
+++ b/stories/Menu/index.stories.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Icon, Menu } from 'semantic-ui-react'
+import { Menu } from 'semantic-ui-react'
 import { storiesOf } from '@storybook/react'
 
 const items = [
@@ -15,55 +15,6 @@ const items = [
 ];
 
 storiesOf('Menu', module)
-  .add('vertical', () => {
-    const items = [
-      {
-        content: 'Header',
-        header: true
-      },
-      {
-        content: 'Home',
-        icon: 'home'
-      },
-      {
-        content: 'Places',
-        icon: 'place'
-      },
-      {
-        content: 'Reports',
-        icon: 'assignment'
-      }
-    ]
-    return (
-      <React.Fragment>
-        <Menu className="blue" vertical items={items} />
-        <Menu className="pink" vertical items={items} />
-        <Menu className="green" vertical items={items} />
-      </React.Fragment>
-    )
-  })
-  .add('vertical icons only', () => {
-    const items = [
-      {
-        icon: 'home'
-      },
-      {
-        icon: 'place'
-      },
-      {
-        icon: 'assignment'
-      }
-    ]
-    return (
-      <React.Fragment>
-        <Menu className="blue" vertical icon items={items} />
-        <br />
-        <Menu className="pink" vertical icon items={items} />
-        <br />
-        <Menu className="green" vertical icon items={items} />
-      </React.Fragment>
-    )
-  })
   .add('basic pointing ', () => <Menu pointing items={items} />)
   .add('secondary pointing ', () => <Menu secondary pointing items={items} />)
   .add('basic pointing blue', () => (

--- a/stories/Menu/vertical.stories.js
+++ b/stories/Menu/vertical.stories.js
@@ -1,5 +1,5 @@
 import React from 'react'
-import { Menu } from 'semantic-ui-react'
+import { Accordion, Icon, Menu } from 'semantic-ui-react'
 import { storiesOf } from '@storybook/react'
 
 storiesOf('Menu/Vertical', module)
@@ -52,10 +52,73 @@ storiesOf('Menu/Vertical', module)
       </React.Fragment>
     )
   })
-  .add('submenus', () => (
-    <Menu className="blue" vertical>
+
+storiesOf('Menu/Vertical/SubMenus/Internal', module)
+  .add('closed', () => (
+    <Menu as={Accordion} className="blue" vertical>
       <Menu.Item link content="Home" icon="home" active />
-      <Menu.Item link content="Places" icon="place" />
+      <Menu.Item link>
+        <Accordion.Title>
+          <Icon name="place" />
+          <span>Places</span>
+          <Icon name="keyboard arrow down" />
+        </Accordion.Title>
+        <Accordion.Content as={Menu.Menu}>
+          <Menu.Item link content="Analytics" icon="timeline" />
+          <Menu.Item link content="Lists" icon="view list" />
+        </Accordion.Content>
+      </Menu.Item>
+      <Menu.Item link content="Reports" icon="assignment" />
+    </Menu>
+  ))
+  .add('open', () => (
+    <Menu as={Accordion} className="blue" vertical>
+      <Menu.Item link content="Home" icon="home" active />
+      <Menu.Item link>
+        <Accordion.Title active>
+          <Icon name="place" />
+          <span>Places</span>
+          <Icon name="keyboard arrow down" />
+        </Accordion.Title>
+        <Accordion.Content as={Menu.Menu} active>
+          <Menu.Item link content="Analytics" icon="timeline" />
+          <Menu.Item link content="Lists" icon="view list" />
+        </Accordion.Content>
+      </Menu.Item>
+      <Menu.Item link content="Reports" icon="assignment" />
+    </Menu>
+  ))
+  .add('open selected', () => (
+    <Menu as={Accordion} className="blue" vertical>
+      <Menu.Item link content="Home" icon="home" />
+      <Menu.Item link active>
+        <Accordion.Title active>
+          <Icon name="place" />
+          <span>Places</span>
+          <Icon name="keyboard arrow down" />
+        </Accordion.Title>
+        <Accordion.Content as={Menu.Menu} active>
+          <Menu.Item link content="Analytics" icon="timeline" active />
+          <Menu.Item link content="Lists" icon="view list" />
+        </Accordion.Content>
+      </Menu.Item>
+      <Menu.Item link content="Reports" icon="assignment" />
+    </Menu>
+  ))
+  .add('closed selected', () => (
+    <Menu as={Accordion} className="blue" vertical>
+      <Menu.Item link content="Home" icon="home" />
+      <Menu.Item link active>
+        <Accordion.Title>
+          <Icon name="place" />
+          <span>Places</span>
+          <Icon name="keyboard arrow down" />
+        </Accordion.Title>
+        <Accordion.Content as={Menu.Menu}>
+          <Menu.Item link content="Analytics" icon="timeline" active />
+          <Menu.Item link content="Lists" icon="view list" />
+        </Accordion.Content>
+      </Menu.Item>
       <Menu.Item link content="Reports" icon="assignment" />
     </Menu>
   ))

--- a/stories/Menu/vertical.stories.js
+++ b/stories/Menu/vertical.stories.js
@@ -1,0 +1,61 @@
+import React from 'react'
+import { Menu } from 'semantic-ui-react'
+import { storiesOf } from '@storybook/react'
+
+storiesOf('Menu/Vertical', module)
+  .add('basic', () => {
+    const items = [
+      {
+        content: 'Header',
+        header: true
+      },
+      {
+        content: 'Home',
+        icon: 'home'
+      },
+      {
+        content: 'Places',
+        icon: 'place'
+      },
+      {
+        content: 'Reports',
+        icon: 'assignment'
+      }
+    ]
+    return (
+      <React.Fragment>
+        <Menu className="blue" vertical items={items} />
+        <Menu className="pink" vertical items={items} />
+        <Menu className="green" vertical items={items} />
+      </React.Fragment>
+    )
+  })
+  .add('icons only', () => {
+    const items = [
+      {
+        icon: 'home'
+      },
+      {
+        icon: 'place'
+      },
+      {
+        icon: 'assignment'
+      }
+    ]
+    return (
+      <React.Fragment>
+        <Menu className="blue" vertical icon items={items} />
+        <br />
+        <Menu className="pink" vertical icon items={items} />
+        <br />
+        <Menu className="green" vertical icon items={items} />
+      </React.Fragment>
+    )
+  })
+  .add('submenus', () => (
+    <Menu className="blue" vertical>
+      <Menu.Item link content="Home" icon="home" active />
+      <Menu.Item link content="Places" icon="place" />
+      <Menu.Item link content="Reports" icon="assignment" />
+    </Menu>
+  ))


### PR DESCRIPTION
I've recently sent a pr for styling vertical menus. This one is for styling inline submenus inside those.

Unfortunately I has to do most of it via overrides, as regular inline submenus in semantic ui don't have the toggle option. I noticed that on their web page code they use an Accordion inside the Menu for this, so I styled our use case using that structure.

![screen recording 2018-12-04 at 12 45 pm](https://user-images.githubusercontent.com/5216049/49453951-e86d6680-f7c2-11e8-86ea-ae0efe12e934.gif)
