### PR TITLE
Style menu lateral sub menu

### DIFF
--- a/src/site/collections/menu.overrides
+++ b/src/site/collections/menu.overrides
@@ -176,12 +176,12 @@
   }
 
   &.header {
-    color: fade(@gray800, 88%);
+    color: @verticalHeaderColor;
     font-size: 12px;
     opacity: 0.5;
 
     &:hover {
-      background-color: @gray00;
+      background-color: @headerBackground;
       cursor: default;
     }
   }
@@ -201,18 +201,29 @@
 }
 
 .ui.blue.vertical.menu .active.item > i.icon:first-child,
-.ui.blue.vertical.menu .active.item .title > i.icon:first-child {
+.ui.blue.vertical.menu .active.item .title > i.icon:first-child,
+.ui.blue.vertical.menu .activeSubMenu.item > i.icon {
   color: @blue;
 }
 
 .ui.pink.vertical.menu .active.item > i.icon:first-child,
-.ui.pink.vertical.menu .active.item .title > i.icon:first-child {
+.ui.pink.vertical.menu .active.item .title > i.icon:first-child,
+.ui.pink.vertical.menu .activeSubMenu.item > i.icon {
   color: @pink;
 }
 
 .ui.green.vertical.menu .active.item > i.icon:first-child,
-.ui.green.vertical.menu .active.item .title > i.icon:first-child {
+.ui.green.vertical.menu .active.item .title > i.icon:first-child,
+.ui.green.vertical.menu .activeSubMenu.item > i.icon {
   color: @green;
+}
+
+.ui.vertical.icon.menu .icon.item {
+  padding: 12px 12px;
+
+  i.icon {
+    height: @iconWidth;
+  }
 }
 
 /*--------------
@@ -270,5 +281,53 @@
         }
       }
     }
+  }
+}
+
+/*--------------
+    Vertical Dropdown Menu
+---------------*/
+
+.ui.vertical.menu .dropdown.item {
+  i.icon {
+    margin-left: 12px;
+    order: 1;
+  }
+
+  .text {
+    order: 2;
+  }
+
+  &.activeSubMenu {
+    background-color: @activeItemBackground;
+  }
+
+  &.active {
+    background-color: fade(@n600, 12%);
+  }
+}
+
+.ui.vertical.menu .ui.dropdown.item > .menu {
+  min-width: 143px;
+  padding: 4px 0 8px;
+
+  .item {
+    align-items: center;
+    display: flex;
+
+    i.icon {
+      align-items: center;
+      display: flex;
+      height: @iconWidth;
+    }
+  }
+
+  .header {
+    background-color: @headerBackground;
+    color: @verticalHeaderColor;
+    font-size: @verticalHeaderFontSize;
+    line-height: 14px;
+    opacity: 0.5;
+    text-transform: @headerTextTransform;
   }
 }

--- a/src/site/collections/menu.variables
+++ b/src/site/collections/menu.variables
@@ -22,6 +22,8 @@
 
 @iconWidth: 24px;
 
+@headerBackground: @gray00;
+@headerTextTransform: none;
 @headerWeight: 400;
 
 @secondaryPointingActiveFontWeight: @itemFontWeight;
@@ -41,8 +43,28 @@
 
 @verticalBoxShadow: @z300BoxShadow;
 
+@verticalHeaderColor: fade(@gray800, 88%);
+@verticalHeaderFontSize: 12px;
+
 @verticalIconFloat: none;
 @verticalIconMargin: 0;
 
 @subMenuFontSize: 14px;
 @subMenuTextColor: @textColor;
+
+/*--------------
+    Dropdown Sub Menu
+---------------*/
+
+@dropdownMenuDistance: 12px;
+
+@dropdownItemPadding: 8px 12px;
+@dropdownItemFontSize: 14px;
+@dropdownItemIconFontSize: 20px;
+
+@dropdownActiveItemBackground: @activeItemBackground;
+@dropdownActiveItemFontWeight: 400;
+@dropdownActiveItemColor: @textColor;
+
+@dropdownHoveredItemBackground: @hoverItemBackground;
+@dropdownHoveredItemColor: @textColor;

--- a/stories/Menu/dropdownSubMenu.stories.js
+++ b/stories/Menu/dropdownSubMenu.stories.js
@@ -1,0 +1,17 @@
+import React from 'react'
+import { Dropdown, Icon, Menu } from 'semantic-ui-react'
+import { storiesOf } from '@storybook/react'
+
+storiesOf('Menu/Vertical/SubMenus/Lateral', module)
+  .add('closed', () => (
+    <Menu className="blue" vertical>
+      <Menu.Item link content="Home" icon="home" active />
+      <Dropdown item text="Places" icon="place">
+        <Dropdown.Menu>
+          <Dropdown.Item text="Analytics" icon="timeline" />
+          <Dropdown.Item text="Lists" icon="view list" />
+        </Dropdown.Menu>
+      </Dropdown>
+      <Menu.Item link content="Reports" icon="assignment" />
+    </Menu>
+  ))

--- a/stories/Menu/dropdownSubMenu.stories.js
+++ b/stories/Menu/dropdownSubMenu.stories.js
@@ -3,12 +3,39 @@ import { Dropdown, Icon, Menu } from 'semantic-ui-react'
 import { storiesOf } from '@storybook/react'
 
 storiesOf('Menu/Vertical/SubMenus/Lateral', module)
-  .add('closed', () => (
+  .add('basic', () => (
     <Menu className="blue" vertical>
       <Menu.Item link content="Home" icon="home" active />
       <Dropdown item text="Places" icon="place">
         <Dropdown.Menu>
+          <Dropdown.Header content="Places" />
           <Dropdown.Item text="Analytics" icon="timeline" />
+          <Dropdown.Item text="Lists" icon="view list" />
+        </Dropdown.Menu>
+      </Dropdown>
+      <Menu.Item link content="Reports" icon="assignment" />
+    </Menu>
+  ))
+  .add('icons only', () => (
+    <Menu className="blue" vertical icon>
+      <Menu.Item link icon="home" active />
+      <Dropdown item icon="place">
+        <Dropdown.Menu>
+          <Dropdown.Header content="Places" />
+          <Dropdown.Item text="Analytics" icon="timeline" />
+          <Dropdown.Item text="Lists" icon="view list" />
+        </Dropdown.Menu>
+      </Dropdown>
+      <Menu.Item link icon="assignment" />
+    </Menu>
+  ))
+  .add('selected', () => (
+    <Menu className="blue" vertical>
+      <Menu.Item link content="Home" icon="home" />
+      <Dropdown className="activeSubMenu" item text="Places" icon="place">
+        <Dropdown.Menu>
+          <Dropdown.Header content="Places" />
+          <Dropdown.Item text="Analytics" icon="timeline" active />
           <Dropdown.Item text="Lists" icon="view list" />
         </Dropdown.Menu>
       </Dropdown>


### PR DESCRIPTION
Just a bit of context for this use case first.

In the main navigation component (which I'll be working on next), we'll be able to expand or collapse the vertical menu. On the expanded version, we'll use the [inline submenu](https://github.com/inloco/supernova-inloco/pull/63). For the collapsed version (icons only) we'll use a dropdown menu, which is the one I'm styling here.

I made it work for all kinds of vertical menus anyway, just letting you know that it's mainly intended for the collapsed version.

**Menu with selected dropdown item**
<img width="383" alt="screen shot 2018-12-05 at 10 07 35 am" src="https://user-images.githubusercontent.com/5216049/49515494-c97bdc80-f875-11e8-9c91-a4b9fb80fa00.png">


**Icons only menu with unselected dropdown item** 
<img width="241" alt="screen shot 2018-12-05 at 10 07 41 am" src="https://user-images.githubusercontent.com/5216049/49515453-b0732b80-f875-11e8-824c-603a4bb92c1b.png">


