### PR TITLE
Add components for the layout header

### DIFF
--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
@@ -63,8 +63,9 @@ class Layout extends Component {
 
   render() {
     const { children, className, color, ...otherProps } = this.props
+    const classes = cx('inloco-layout', className)
     return (
-      <div className={classNames('inloco-layout', className)} {...otherProps}>
+      <div className={classes} {...otherProps}>
         {React.Children.map(children, child =>
           React.cloneElement(child, { color })
         )}

--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -1,9 +1,14 @@
+import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
 import LayoutSidebar from './Sidebar'
 import LayoutSidebarItem from './Sidebar/Item'
 import LayoutTopbar from './Topbar'
+import LayoutMain from './Main'
+import LayoutHeader from './Main/Header'
+import LayoutHeaderTitle from './Main/Header/Title'
+import LayoutHeaderControls from './Main/Header/Controls'
 
 /**
  * TODO: Remove this block once everything is ready and the story file is
@@ -31,7 +36,7 @@ import LayoutTopbar from './Topbar'
  *      items={subMenuItems}
  *    />
  *  </Layout.Sidebar>
- *  <Layout.Main logo={logo}>
+ *  <Layout.Main>
  *    <Layout.Header>
  *      <Layout.HeaderTitle>{title}</Layout.HeaderTitle>
  *      {headerChildren}
@@ -44,17 +49,22 @@ import LayoutTopbar from './Topbar'
 class Layout extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
+    className: PropTypes.string,
     color: PropTypes.string
   }
 
   static Sidebar = LayoutSidebar
   static SidebarItem = LayoutSidebarItem
   static Topbar = LayoutTopbar
+  static Main = LayoutMain
+  static Header = LayoutHeader
+  static HeaderTitle = LayoutHeaderTitle
+  static HeaderControls = LayoutHeaderControls
 
   render() {
-    const { children, color } = this.props
+    const { children, className, color, ...otherProps } = this.props
     return (
-      <div className="inloco-layout">
+      <div className={classNames('inloco-layout', className)} {...otherProps}>
         {React.Children.map(children, child =>
           React.cloneElement(child, { color })
         )}

--- a/components/Layout/Main/Header/Controls/index.js
+++ b/components/Layout/Main/Header/Controls/index.js
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
@@ -10,10 +10,9 @@ class HeaderControls extends Component {
 
   render() {
     const { children, className, ...otherProps } = this.props
+    const classes = cx('inloco-layout__header-controls', className)
     return (
-      <div
-        className={classNames('inloco-layout__header-controls', className)}
-        {...otherProps}>
+      <div className={classes} {...otherProps}>
         {children}
       </div>
     )

--- a/components/Layout/Main/Header/Controls/index.js
+++ b/components/Layout/Main/Header/Controls/index.js
@@ -1,0 +1,23 @@
+import classNames from 'classnames'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+class HeaderControls extends Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string
+  }
+
+  render() {
+    const { children, className, ...otherProps } = this.props
+    return (
+      <div
+        className={classNames('inloco-layout__header-controls', className)}
+        {...otherProps}>
+        {children}
+      </div>
+    )
+  }
+}
+
+export default HeaderControls

--- a/components/Layout/Main/Header/Title/index.js
+++ b/components/Layout/Main/Header/Title/index.js
@@ -1,0 +1,23 @@
+import classNames from 'classnames'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+class HeaderTitle extends Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string
+  }
+
+  render() {
+    const { children, className, ...otherProps } = this.props
+    return (
+      <div
+        className={classNames('inloco-layout__header-title', className)}
+        {...otherProps}>
+        {children}
+      </div>
+    )
+  }
+}
+
+export default HeaderTitle

--- a/components/Layout/Main/Header/Title/index.js
+++ b/components/Layout/Main/Header/Title/index.js
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
@@ -10,10 +10,9 @@ class HeaderTitle extends Component {
 
   render() {
     const { children, className, ...otherProps } = this.props
+    const classes = cx('inloco-layout__header-title', className)
     return (
-      <div
-        className={classNames('inloco-layout__header-title', className)}
-        {...otherProps}>
+      <div className={classes} {...otherProps}>
         {children}
       </div>
     )

--- a/components/Layout/Main/Header/index.js
+++ b/components/Layout/Main/Header/index.js
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
@@ -10,10 +10,9 @@ class Header extends Component {
 
   render() {
     const { children, className, ...otherProps } = this.props
+    const classes = cx('inloco-layout__header', className)
     return (
-      <div
-        className={classNames('inloco-layout__header', className)}
-        {...otherProps}>
+      <div className={classes} {...otherProps}>
         {children}
       </div>
     )

--- a/components/Layout/Main/Header/index.js
+++ b/components/Layout/Main/Header/index.js
@@ -1,0 +1,23 @@
+import classNames from 'classnames'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+class Header extends Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string
+  }
+
+  render() {
+    const { children, className, ...otherProps } = this.props
+    return (
+      <div
+        className={classNames('inloco-layout__header', className)}
+        {...otherProps}>
+        {children}
+      </div>
+    )
+  }
+}
+
+export default Header

--- a/components/Layout/Main/index.js
+++ b/components/Layout/Main/index.js
@@ -1,0 +1,23 @@
+import classNames from 'classnames'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+class Main extends Component {
+  static propTypes = {
+    children: PropTypes.node.isRequired,
+    className: PropTypes.string
+  }
+
+  render() {
+    const { children, className, ...otherProps } = this.props
+    return (
+      <div
+        className={classNames('inloco-layout__main', className)}
+        {...otherProps}>
+        {children}
+      </div>
+    )
+  }
+}
+
+export default Main

--- a/components/Layout/Main/index.js
+++ b/components/Layout/Main/index.js
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
@@ -10,10 +10,9 @@ class Main extends Component {
 
   render() {
     const { children, className, ...otherProps } = this.props
+    const classes = cx('inloco-layout__main', className)
     return (
-      <div
-        className={classNames('inloco-layout__main', className)}
-        {...otherProps}>
+      <div className={classes} {...otherProps}>
         {children}
       </div>
     )

--- a/components/Layout/Sidebar/Item/index.js
+++ b/components/Layout/Sidebar/Item/index.js
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
@@ -6,14 +6,16 @@ import { Menu } from 'semantic-ui-react'
 
 class SidebarItem extends Component {
   static propTypes = {
+    className: PropTypes.string,
     expanded: PropTypes.bool
   }
 
   render() {
-    const { content, expanded, ...otherProps } = this.props
+    const { className, content, expanded, ...otherProps } = this.props
+    const classes = cx('inloco-layout__sidebar-item', className)
     return (
       <Menu.Item
-        className="inloco-layout__sidebar-item"
+        className={classes}
         link
         content={expanded ? content : null}
         {...otherProps}

--- a/components/Layout/Sidebar/index.js
+++ b/components/Layout/Sidebar/index.js
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Accordion, Icon, Menu } from 'semantic-ui-react'
@@ -22,7 +22,7 @@ class Sidebar extends Component {
     const { children, color, headerTitle } = this.props
     const { expanded } = this.state
 
-    const classes = classNames('inloco-layout__sidebar', color, { expanded })
+    const classes = cx('inloco-layout__sidebar', color, { expanded })
     const headerIcon = expanded ? 'close' : 'menu'
     return (
       <Menu as={Accordion} className={classes} vertical icon={!expanded}>

--- a/components/Layout/Topbar/index.js
+++ b/components/Layout/Topbar/index.js
@@ -1,4 +1,4 @@
-import classNames from 'classnames'
+import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
@@ -7,13 +7,15 @@ import { Menu } from 'semantic-ui-react'
 class Topbar extends Component {
   static propTypes = {
     children: PropTypes.node,
+    className: PropTypes.string,
     logo: PropTypes.node.isRequired
   }
 
   render() {
-    const { children, logo, ...otherProps } = this.props
+    const { children, className, logo, ...otherProps } = this.props
+    const classes = cx('inloco-layout__topbar', className)
     return (
-      <Menu className="inloco-layout__topbar" {...otherProps}>
+      <Menu className={classes} {...otherProps}>
         <div className="inloco-layout__topbar-logo">{logo}</div>
         {children}
       </Menu>

--- a/src/definitions/inloco/layout.less
+++ b/src/definitions/inloco/layout.less
@@ -17,6 +17,11 @@
 
 .inloco-layout {
   background-color: @gray50;
+  display: grid;
+  grid-template:
+    'sidebar topbar' 64px
+    'sidebar main'
+    / 64px;
   max-height: 100vh;
   overflow-y: auto;
   width: 100vw;
@@ -27,6 +32,7 @@
 ---------------*/
 
 .inloco-layout__sidebar.ui.vertical.menu {
+  grid-area: sidebar;
   height: 100vh;
   left: 0;
   margin: 0;
@@ -62,8 +68,9 @@
   border: none;
   border-radius: 0;
   box-shadow: 0 2px 3px -2px fade(@n600, 5%);
+  grid-area: topbar;
   height: 64px;
-  margin: 0 0 0 64px;
+  margin: 0;
 }
 
 .inloco-layout__topbar-logo {
@@ -76,7 +83,8 @@
 ---------------*/
 
 .inloco-layout__main {
-  margin: 0 32px 0 96px;
+  grid-area: main;
+  margin: 0 32px;
 }
 
 /*--------------

--- a/src/definitions/inloco/layout.less
+++ b/src/definitions/inloco/layout.less
@@ -16,6 +16,9 @@
 ---------------*/
 
 .inloco-layout {
+  background-color: @gray50;
+  max-height: 100vh;
+  overflow-y: auto;
   width: 100vw;
 }
 
@@ -66,4 +69,35 @@
 .inloco-layout__topbar-logo {
   display: flex;
   margin-left: 30px;
+}
+
+/*--------------
+    Layout Main
+---------------*/
+
+.inloco-layout__main {
+  margin: 0 32px 0 96px;
+}
+
+/*--------------
+    Layout Header
+---------------*/
+
+.inloco-layout__header {
+  display: flex;
+  justify-content: space-between;
+  margin: 32px 0;
+}
+
+.inloco-layout__header-title {
+  color: @gray800;
+  font-size: 24px;
+  font-weight: 300;
+  letter-spacing: 0.3px;
+}
+
+.inloco-layout__header-controls {
+  > :not(:first-child) {
+    margin-left: 16px;
+  }
 }

--- a/stories/Layout/index.stories.js
+++ b/stories/Layout/index.stories.js
@@ -1,63 +1,72 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Dropdown, Layout, Menu } from '../../components'
+import { Button, Dropdown, Layout, Menu, Placeholder } from '../../components'
 import engage from './images/engage.svg'
 
 import './layoutStory.css'
 
+const StoryLayout = props => (
+  <Layout className="layout-story" {...props}>
+    <Layout.Sidebar>
+      <Layout.SidebarItem content="Home" icon="home" active />
+      <Layout.SidebarItem content="Reports" icon="assignment" />
+    </Layout.Sidebar>
+    <Layout.Topbar logo={<img src={engage} />}>
+      <Menu.Menu position="right">
+        <Dropdown item text="Maira Bello">
+          <Dropdown.Menu>
+            <Dropdown.Item text="Account" />
+            <Dropdown.Item text="Logout" />
+          </Dropdown.Menu>
+        </Dropdown>
+      </Menu.Menu>
+    </Layout.Topbar>
+    <Layout.Main>
+      <Layout.Header>
+        <Layout.HeaderTitle>Home Title</Layout.HeaderTitle>
+        <Layout.HeaderControls>
+          <Button>Cancel</Button>
+          <Button className={props.color}>Save</Button>
+        </Layout.HeaderControls>
+      </Layout.Header>
+      <Placeholder fluid>
+        <Placeholder.Paragraph>
+          <Placeholder.Line />
+          <Placeholder.Line />
+          <Placeholder.Line />
+          <Placeholder.Line />
+        </Placeholder.Paragraph>
+        <Placeholder.Paragraph>
+          <Placeholder.Line />
+          <Placeholder.Line />
+          <Placeholder.Line />
+          <Placeholder.Line />
+        </Placeholder.Paragraph>
+        <Placeholder.Paragraph>
+          <Placeholder.Line />
+          <Placeholder.Line />
+          <Placeholder.Line />
+          <Placeholder.Line />
+        </Placeholder.Paragraph>
+        <Placeholder.Paragraph>
+          <Placeholder.Line />
+          <Placeholder.Line />
+          <Placeholder.Line />
+          <Placeholder.Line />
+        </Placeholder.Paragraph>
+        <Placeholder.Paragraph>
+          <Placeholder.Line />
+          <Placeholder.Line />
+          <Placeholder.Line />
+          <Placeholder.Line />
+        </Placeholder.Paragraph>
+      </Placeholder>
+    </Layout.Main>
+  </Layout>
+)
+
 storiesOf('Layout', module)
-  .add('blue', () => (
-    <Layout color="blue">
-      <Layout.Sidebar>
-        <Layout.SidebarItem content="Home" icon="home" active />
-        <Layout.SidebarItem content="Reports" icon="assignment" />
-      </Layout.Sidebar>
-      <Layout.Topbar logo={<img src={engage} />}>
-        <Menu.Menu position="right">
-          <Dropdown item text="Maira Bello">
-            <Dropdown.Menu>
-              <Dropdown.Item text="Account" />
-              <Dropdown.Item text="Logout" />
-            </Dropdown.Menu>
-          </Dropdown>
-        </Menu.Menu>
-      </Layout.Topbar>
-    </Layout>
-  ))
-  .add('pink', () => (
-    <Layout color="pink">
-      <Layout.Sidebar>
-        <Layout.SidebarItem content="Home" icon="home" active />
-        <Layout.SidebarItem content="Reports" icon="assignment" />
-      </Layout.Sidebar>
-      <Layout.Topbar logo={<img src={engage} />}>
-        <Menu.Menu position="right">
-          <Dropdown item text="Maira Bello">
-            <Dropdown.Menu>
-              <Dropdown.Item text="Account" />
-              <Dropdown.Item text="Logout" />
-            </Dropdown.Menu>
-          </Dropdown>
-        </Menu.Menu>
-      </Layout.Topbar>
-    </Layout>
-  ))
-  .add('green', () => (
-    <Layout color="green">
-      <Layout.Sidebar>
-        <Layout.SidebarItem content="Home" icon="home" active />
-        <Layout.SidebarItem content="Reports" icon="assignment" />
-      </Layout.Sidebar>
-      <Layout.Topbar logo={<img src={engage} />}>
-        <Menu.Menu position="right">
-          <Dropdown item text="Maira Bello">
-            <Dropdown.Menu>
-              <Dropdown.Item text="Account" />
-              <Dropdown.Item text="Logout" />
-            </Dropdown.Menu>
-          </Dropdown>
-        </Menu.Menu>
-      </Layout.Topbar>
-    </Layout>
-  ))
+  .add('blue', () => <StoryLayout color="blue" />)
+  .add('pink', () => <StoryLayout color="pink" />)
+  .add('green', () => <StoryLayout color="green" />)

--- a/stories/Layout/layoutStory.css
+++ b/stories/Layout/layoutStory.css
@@ -1,3 +1,8 @@
 #root {
   margin: 0 !important;
 }
+
+.layout-story .ui.placeholder .line,
+.layout-story .ui.placeholder .paragraph:before {
+  background-color: #fafbfc;
+}


### PR DESCRIPTION
This header is now only missing:
- Breadcrumbs
- Behavior of becoming fixed when it reaches the top of the page

<img width="1186" alt="screen shot 2018-12-06 at 12 47 52 pm" src="https://user-images.githubusercontent.com/5216049/49594697-37e39c00-f955-11e8-9c7c-24bb5c75c1a1.png">
