### PR TITLE
Layout sidebar footer, divider and click outside

### DIFF
--- a/components/Layout/Layout.js
+++ b/components/Layout/Layout.js
@@ -5,6 +5,7 @@ import React, { Component } from 'react'
 import LayoutSidebar from './Sidebar'
 import LayoutSidebarItem from './Sidebar/Item'
 import LayoutSidebarSubmenu from './Sidebar/Submenu'
+import LayoutSidebarFooter from './Sidebar/Footer'
 import LayoutTopbar from './Topbar'
 import LayoutMain from './Main'
 import LayoutHeader from './Main/Header'
@@ -22,6 +23,7 @@ class Layout extends Component {
   static Sidebar = LayoutSidebar
   static SidebarItem = LayoutSidebarItem
   static SidebarSubmenu = LayoutSidebarSubmenu
+  static SidebarFooter = LayoutSidebarFooter
   static Topbar = LayoutTopbar
   static Main = LayoutMain
   static Header = LayoutHeader

--- a/components/Layout/Sidebar/Footer/index.js
+++ b/components/Layout/Sidebar/Footer/index.js
@@ -1,0 +1,29 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { Divider } from 'semantic-ui-react'
+
+class Footer extends Component {
+  static propTypes = {
+    className: PropTypes.string,
+    children: PropTypes.node.isRequired,
+    expanded: PropTypes.bool.isRequired
+  }
+
+  render() {
+    const { className, children, expanded, ...otherProps } = this.props
+    const classes = cx('inloco-layout__sidebar-footer', className)
+    return (
+      <React.Fragment>
+        <Divider />
+        <div className={classes} {...otherProps}>
+          {React.Children.map(children, child =>
+            React.cloneElement(child, { expanded })
+          )}
+        </div>
+      </React.Fragment>
+    )
+  }
+}
+
+export default Footer

--- a/components/Layout/Sidebar/Submenu/index.js
+++ b/components/Layout/Sidebar/Submenu/index.js
@@ -10,7 +10,7 @@ class SidebarSubmenu extends Component {
   static propTypes = {
     className: PropTypes.string,
     content: PropTypes.node.isRequired,
-    icon: PropTypes.string,
+    icon: PropTypes.string.isRequired,
     expanded: PropTypes.bool
   }
 

--- a/components/Layout/Sidebar/Submenu/index.js
+++ b/components/Layout/Sidebar/Submenu/index.js
@@ -10,7 +10,7 @@ class SidebarSubmenu extends Component {
   static propTypes = {
     className: PropTypes.string,
     content: PropTypes.node.isRequired,
-    icon: PropTypes.string.isRequired,
+    icon: PropTypes.string,
     expanded: PropTypes.bool
   }
 

--- a/components/Layout/Sidebar/index.js
+++ b/components/Layout/Sidebar/index.js
@@ -39,6 +39,7 @@ class Sidebar extends Component {
           className="inloco-layout__sidebar-dimmer"
           active={expanded}
           page
+          onClick={this.handleDimmerClick}
         />
       </React.Fragment>
     )
@@ -46,6 +47,10 @@ class Sidebar extends Component {
 
   handleHeaderIconClick = () => {
     this.setState(({ expanded }) => ({ expanded: !expanded }))
+  }
+
+  handleDimmerClick = () => {
+    this.setState({ expanded: false })
   }
 }
 

--- a/components/Layout/Sidebar/index.js
+++ b/components/Layout/Sidebar/index.js
@@ -7,6 +7,7 @@ class Sidebar extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
     color: PropTypes.string,
+    expanded: PropTypes.bool.isRequired,
     headerTitle: PropTypes.string
   }
 

--- a/src/definitions/inloco/layout.less
+++ b/src/definitions/inloco/layout.less
@@ -29,6 +29,7 @@
 
 .inloco-layout__sidebar.ui.vertical.menu {
   border-radius: 0;
+  display: flex;
   grid-area: sidebar;
   height: 100vh;
   left: 0;
@@ -58,8 +59,26 @@
   }
 
   .ui.divider {
-    margin-left: -8px;
-    margin-right: -8px;
+    margin: 8px -8px 16px -8px;
+  }
+}
+
+.inloco-layout__sidebar-footer {
+  display: flex;
+  flex: 1;
+  flex-direction: column;
+  justify-content: flex-end;
+}
+
+.inloco-layout__sidebar.ui.vertical.menu {
+  .inloco-layout__sidebar-footer {
+    .inloco-layout__sidebar-submenu-accordion.item {
+      flex-direction: column-reverse;
+
+      .menu.content {
+        margin: 0 0 12px;
+      }
+    }
   }
 }
 

--- a/src/definitions/inloco/layout.less
+++ b/src/definitions/inloco/layout.less
@@ -56,6 +56,11 @@
       }
     }
   }
+
+  .ui.divider {
+    margin-left: -8px;
+    margin-right: -8px;
+  }
 }
 
 /*--------------

--- a/src/site/collections/menu.overrides
+++ b/src/site/collections/menu.overrides
@@ -350,3 +350,13 @@
     text-transform: @headerTextTransform;
   }
 }
+
+/*--------------
+    Divider
+---------------*/
+
+.ui.menu .ui.divider {
+  border-bottom: 0;
+  border-color: fade(@n600, 8%);
+  margin: 16px 0;
+}

--- a/src/site/collections/menu.overrides
+++ b/src/site/collections/menu.overrides
@@ -309,6 +309,7 @@
 
 .ui.vertical.menu .dropdown.item {
   i.icon {
+    height: @iconWidth;
     margin-left: 12px;
     order: 1;
   }
@@ -327,12 +328,13 @@
 }
 
 .ui.vertical.menu .ui.dropdown.item > .menu {
-  min-width: 143px;
+  min-width: max-content;
   padding: 4px 0 8px;
 
   .item {
     align-items: center;
     display: flex;
+    min-width: 143px;
 
     i.icon {
       align-items: center;

--- a/stories/Layout/index.stories.js
+++ b/stories/Layout/index.stories.js
@@ -23,6 +23,12 @@ const StoryLayout = props => (
         <Layout.SidebarItem content="Analytics" icon="timeline" />
         <Layout.SidebarItem content="Lists" icon="view list" />
       </Layout.SidebarSubmenu>
+      <Layout.SidebarFooter>
+        <Layout.SidebarSubmenu content="Help" icon="help">
+          <Layout.SidebarItem content="About" icon="help" />
+          <Layout.SidebarItem content="Documentation" icon="help" />
+        </Layout.SidebarSubmenu>
+      </Layout.SidebarFooter>
     </Layout.Sidebar>
     <Layout.Topbar logo={<img src={engage} />}>
       <Menu.Menu position="right">

--- a/stories/Layout/index.stories.js
+++ b/stories/Layout/index.stories.js
@@ -1,7 +1,14 @@
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Button, Dropdown, Layout, Menu, Placeholder } from '../../components'
+import {
+  Button,
+  Divider,
+  Dropdown,
+  Layout,
+  Menu,
+  Placeholder
+} from '../../components'
 import engage from './images/engage.svg'
 
 import './layoutStory.css'
@@ -11,6 +18,7 @@ const StoryLayout = props => (
     <Layout.Sidebar>
       <Layout.SidebarItem content="Home" icon="home" active />
       <Layout.SidebarItem content="Reports" icon="assignment" />
+      <Divider />
       <Layout.SidebarSubmenu content="Places" icon="place">
         <Layout.SidebarItem content="Analytics" icon="timeline" />
         <Layout.SidebarItem content="Lists" icon="view list" />


### PR DESCRIPTION
- Styles menu dividers for the sidebar.
- Collapses the sidebar when the dimmer is clicked
- Adds `<Layout.SidebarFooter>` component to allow easily adding a submenu to the bottom of the sidebar. In a final footer pr this will be fixed at the bottom so the rest of the sidebar can be scrolled if the height is too small.

<img width="1186" alt="screen shot 2018-12-07 at 12 51 49 pm" src="https://user-images.githubusercontent.com/5216049/49657663-f3243780-fa1e-11e8-8733-a16b1deb41c0.png">
<img width="1187" alt="screen shot 2018-12-07 at 12 51 56 pm" src="https://user-images.githubusercontent.com/5216049/49657664-f3243780-fa1e-11e8-925a-f5b71bd95ec1.png">
