### PR TITLE
Fix react errors

### DIFF
--- a/components/Layout/Sidebar/Item/index.js
+++ b/components/Layout/Sidebar/Item/index.js
@@ -8,7 +8,8 @@ class SidebarItem extends Component {
   static propTypes = {
     className: PropTypes.string,
     dropdown: PropTypes.bool,
-    expanded: PropTypes.bool
+    expanded: PropTypes.bool,
+    icon: PropTypes.string
   }
 
   static defaultProps = {
@@ -16,7 +17,14 @@ class SidebarItem extends Component {
   }
 
   render() {
-    const { className, content, dropdown, expanded, ...otherProps } = this.props
+    const {
+      className,
+      content,
+      dropdown,
+      expanded,
+      icon,
+      ...otherProps
+    } = this.props
     const classes = cx('inloco-layout__sidebar-item', className)
 
     if (dropdown) {
@@ -30,6 +38,7 @@ class SidebarItem extends Component {
         className={classes}
         link
         content={expanded ? content : null}
+        icon={icon ? { className: icon } : null}
         {...otherProps}
       />
     )

--- a/components/Layout/Sidebar/Submenu/Dropdown.js
+++ b/components/Layout/Sidebar/Submenu/Dropdown.js
@@ -25,7 +25,11 @@ class SidebarSubmenuDropdown extends Component {
       activeSubMenu: active
     })
     return (
-      <Dropdown className={classes} item icon={icon} {...otherProps}>
+      <Dropdown
+        className={classes}
+        item
+        icon={{ className: icon }}
+        {...otherProps}>
         <Dropdown.Menu>
           <Dropdown.Header content={content} />
           {React.Children.map(children, child =>

--- a/components/Layout/Sidebar/index.js
+++ b/components/Layout/Sidebar/index.js
@@ -3,6 +3,10 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Accordion, Dimmer, Icon, Menu } from 'semantic-ui-react'
 
+import LayoutSidebarItem from './Item'
+import LayoutSidebarSubmenu from './Submenu'
+import LayoutSidebarFooter from './Footer'
+
 class Sidebar extends Component {
   static propTypes = {
     children: PropTypes.node.isRequired,
@@ -31,9 +35,16 @@ class Sidebar extends Component {
             <Icon className={headerIcon} onClick={this.handleHeaderIconClick} />
             {expanded && headerTitle}
           </Menu.Item>
-          {React.Children.map(children, child =>
-            React.cloneElement(child, { expanded })
-          )}
+          {React.Children.map(children, child => {
+            if (
+              child.type === LayoutSidebarItem ||
+              child.type === LayoutSidebarSubmenu ||
+              child.type === LayoutSidebarFooter
+            ) {
+              return React.cloneElement(child, { expanded })
+            }
+            return child
+          })}
         </Menu>
         <Dimmer
           className="inloco-layout__sidebar-dimmer"


### PR DESCRIPTION
Two fixes to stop throwing react warnings when using the Layout component. I've noticed these in storybook.

**Stop passing "expanded" to unknown children.**

`<Divider/>` should not receive this prop, for example. 

**Fix prop type errors for icons inside the layout sidebar**

The icons we use are not the default icons for react semantic ui, so passing them directly as `icon` throws some warnings in the console for icons that were not expected.

We need to instead pass them as `className`. To have this be transparent for people using Layout, I'm doing this conversion inside `Layout.SidebarItem` and `Layout.SidebarSubMenu`.