### PR TITLE
Layout tooltips for collapsed sidebar

### DIFF
--- a/components/Layout/Sidebar/Item/index.js
+++ b/components/Layout/Sidebar/Item/index.js
@@ -2,7 +2,7 @@ import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 
-import { Dropdown, Menu } from 'semantic-ui-react'
+import { Dropdown, Menu, Popup } from 'semantic-ui-react'
 
 class SidebarItem extends Component {
   static propTypes = {
@@ -33,7 +33,7 @@ class SidebarItem extends Component {
       )
     }
 
-    return (
+    const item = (
       <Menu.Item
         className={classes}
         link
@@ -42,6 +42,19 @@ class SidebarItem extends Component {
         {...otherProps}
       />
     )
+
+    if (!expanded) {
+      return (
+        <Popup
+          inverted
+          size="tiny"
+          position="center right"
+          content={content}
+          trigger={item}
+        />
+      )
+    }
+    return item
   }
 }
 

--- a/components/Layout/Sidebar/Submenu/Dropdown.js
+++ b/components/Layout/Sidebar/Submenu/Dropdown.js
@@ -1,7 +1,7 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { Dropdown } from 'semantic-ui-react'
+import { Dropdown, Popup } from 'semantic-ui-react'
 
 class SidebarSubmenuDropdown extends Component {
   static propTypes = {
@@ -24,7 +24,8 @@ class SidebarSubmenuDropdown extends Component {
     const classes = cx('inloco-layout__sidebar-submenu-dropdown', className, {
       activeSubMenu: active
     })
-    return (
+
+    const dropdown = (
       <Dropdown
         className={classes}
         item
@@ -37,6 +38,15 @@ class SidebarSubmenuDropdown extends Component {
           )}
         </Dropdown.Menu>
       </Dropdown>
+    )
+    return (
+      <Popup
+        inverted
+        size="tiny"
+        position="center right"
+        content={content}
+        trigger={dropdown}
+      />
     )
   }
 }

--- a/src/site/modules/popup.overrides
+++ b/src/site/modules/popup.overrides
@@ -1,3 +1,15 @@
 /*******************************
         User Overrides
 *******************************/
+
+.ui.tiny.popup {
+  padding: 4px 14px;
+
+  &.right::before {
+    left: -3px;
+  }
+
+  &.left::before {
+    right: -3px;
+  }
+}

--- a/stories/Popup/index.stories.js
+++ b/stories/Popup/index.stories.js
@@ -11,7 +11,9 @@ storiesOf('Popup', module)
         content="Bottom Popup"
         on="click"
         position="bottom center"
-        trigger={<Button className="popup-story__button">Trigger Bottom</Button>}
+        trigger={
+          <Button className="popup-story__button">Trigger Bottom</Button>
+        }
       />
       <Popup
         content="Right Popup"
@@ -29,6 +31,40 @@ storiesOf('Popup', module)
         content="Left Popup"
         on="click"
         position="center left"
+        trigger={<Button className="popup-story__button">Trigger Left</Button>}
+      />
+    </div>
+  ))
+  .add('inverted', () => (
+    <div className="popup-story">
+      <Popup
+        content="Bottom Popup"
+        on="click"
+        position="bottom center"
+        inverted
+        trigger={
+          <Button className="popup-story__button">Trigger Bottom</Button>
+        }
+      />
+      <Popup
+        content="Right Popup"
+        on="click"
+        position="center right"
+        inverted
+        trigger={<Button className="popup-story__button">Trigger Right</Button>}
+      />
+      <Popup
+        content="Top Popup"
+        on="click"
+        position="top center"
+        inverted
+        trigger={<Button className="popup-story__button">Trigger Top</Button>}
+      />
+      <Popup
+        content="Left Popup"
+        on="click"
+        position="center left"
+        inverted
         trigger={<Button className="popup-story__button">Trigger Left</Button>}
       />
     </div>


### PR DESCRIPTION
On the collapsed sidebar, we'll show tooltips when the user hovers over an icon.

<img width="1187" alt="screen shot 2018-12-13 at 11 19 58 am" src="https://user-images.githubusercontent.com/5216049/49944517-543d8680-fec9-11e8-9be5-9260c988e5db.png">
