### PR TITLE
Pass sidebar expanded state via context instead of props

### DIFF
--- a/components/Layout/Sidebar/Footer/index.js
+++ b/components/Layout/Sidebar/Footer/index.js
@@ -6,20 +6,17 @@ import { Divider } from 'semantic-ui-react'
 class Footer extends Component {
   static propTypes = {
     className: PropTypes.string,
-    children: PropTypes.node.isRequired,
-    expanded: PropTypes.bool
+    children: PropTypes.node.isRequired
   }
 
   render() {
-    const { className, children, expanded, ...otherProps } = this.props
+    const { className, children, ...otherProps } = this.props
     const classes = cx('inloco-layout__sidebar-footer', className)
     return (
       <React.Fragment>
         <Divider />
         <div className={classes} {...otherProps}>
-          {React.Children.map(children, child =>
-            React.cloneElement(child, { expanded })
-          )}
+          {children}
         </div>
       </React.Fragment>
     )

--- a/components/Layout/Sidebar/Item/index.js
+++ b/components/Layout/Sidebar/Item/index.js
@@ -1,35 +1,32 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-
 import { Dropdown, Menu, Popup } from 'semantic-ui-react'
+
+import SidebarContext from '../SidebarContext'
 
 class SidebarItem extends Component {
   static propTypes = {
     className: PropTypes.string,
     dropdown: PropTypes.bool,
-    expanded: PropTypes.bool,
     icon: PropTypes.string
   }
 
-  static defaultProps = {
-    expanded: true
-  }
+  static contextType = SidebarContext
 
   render() {
-    const {
-      className,
-      content,
-      dropdown,
-      expanded,
-      icon,
-      ...otherProps
-    } = this.props
+    const { className, content, dropdown, icon, ...otherProps } = this.props
+    const { expanded } = this.context
     const classes = cx('inloco-layout__sidebar-item', className)
 
     if (dropdown) {
       return (
-        <Dropdown.Item className={classes} text={content} {...otherProps} />
+        <Dropdown.Item
+          className={classes}
+          text={content}
+          icon={icon}
+          {...otherProps}
+        />
       )
     }
 

--- a/components/Layout/Sidebar/SidebarContext.js
+++ b/components/Layout/Sidebar/SidebarContext.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const SidebarContext = React.createContext('layout-sidebar')
+
+export default SidebarContext

--- a/components/Layout/Sidebar/Submenu/index.js
+++ b/components/Layout/Sidebar/Submenu/index.js
@@ -5,19 +5,21 @@ import { Menu } from 'semantic-ui-react'
 
 import SidebarSubmenuAccordion from './Accordion'
 import SidebarSubmenuDropdown from './Dropdown'
+import SidebarContext from '../SidebarContext'
 
 class SidebarSubmenu extends Component {
   static propTypes = {
     className: PropTypes.string,
     content: PropTypes.node.isRequired,
-    icon: PropTypes.string.isRequired,
-    expanded: PropTypes.bool
+    icon: PropTypes.string.isRequired
   }
 
+  static contextType = SidebarContext
+
   render() {
-    const { className, expanded, ...otherProps } = this.props
+    const { className, ...otherProps } = this.props
     const classes = cx('inloco-layout__sidebar-submenu', className)
-    const ElementType = expanded
+    const ElementType = this.context.expanded
       ? SidebarSubmenuAccordion
       : SidebarSubmenuDropdown
     return <ElementType className={classes} {...otherProps} />

--- a/components/Layout/Sidebar/index.js
+++ b/components/Layout/Sidebar/index.js
@@ -3,10 +3,8 @@ import PropTypes from 'prop-types'
 import React, { Component } from 'react'
 import { Accordion, Dimmer, Icon, Menu } from 'semantic-ui-react'
 
-import LayoutSidebarItem from './Item'
-import LayoutSidebarSubmenu from './Submenu'
-import LayoutSidebarFooter from './Footer'
 import LayoutContext from '../LayoutContext'
+import SidebarContext from './SidebarContext'
 
 class Sidebar extends Component {
   static propTypes = {
@@ -38,16 +36,9 @@ class Sidebar extends Component {
             <Icon className={headerIcon} onClick={this.handleHeaderIconClick} />
             {expanded && headerTitle}
           </Menu.Item>
-          {React.Children.map(children, child => {
-            if (
-              child.type === LayoutSidebarItem ||
-              child.type === LayoutSidebarSubmenu ||
-              child.type === LayoutSidebarFooter
-            ) {
-              return React.cloneElement(child, { expanded })
-            }
-            return child
-          })}
+          <SidebarContext.Provider value={{ expanded }}>
+            {children}
+          </SidebarContext.Provider>
         </Menu>
         <Dimmer
           className="inloco-layout__sidebar-dimmer"


### PR DESCRIPTION
Passing them as props to direct children makes it impossible for developers to have intermediary components, making organization hard.

This also makes the code cleaner, I've deleted more lines than added them :)

Finally, this will it will follow the same pattern we're using for layout context data.