### PR TITLE
Fix react warning due to not passing icon as className in Layout.Sidebar.Item

### DIFF
--- a/components/Layout/Sidebar/Item/index.js
+++ b/components/Layout/Sidebar/Item/index.js
@@ -24,7 +24,7 @@ class SidebarItem extends Component {
         <Dropdown.Item
           className={classes}
           text={content}
-          icon={icon}
+          icon={{ className: icon }}
           {...otherProps}
         />
       )


### PR DESCRIPTION
I seriously need to start checking the react warnings before every pr. I usually always keep the console open, but since Layout takes a big space on the page, I'm not doing it in this case.