### PR TITLE
Style small vertical menu with only icons

### DIFF
--- a/src/site/collections/menu.overrides
+++ b/src/site/collections/menu.overrides
@@ -238,7 +238,7 @@
 }
 
 .ui.vertical.icon.menu .icon.item {
-  padding: 12px 12px;
+  padding: 12px;
 
   i.icon {
     height: @iconWidth;
@@ -255,6 +255,20 @@
 .ui.vertical.menu .dropdown.item:active {
   background-color: fade(@n600, 8%);
 }
+
+/*--------------
+    Vertical Small
+---------------*/
+
+.ui.vertical.small.icon.menu .icon.item {
+  margin-bottom: 16px;
+  padding: 4px;
+
+  &:last-child {
+    margin-bottom: 0;
+  }
+}
+
 
 /*--------------
     Vertical Accordion Menu

--- a/src/site/collections/menu.variables
+++ b/src/site/collections/menu.variables
@@ -54,6 +54,8 @@
 @subMenuFontSize: 14px;
 @subMenuTextColor: @textColor;
 
+@smallWidth: 48px;
+
 /*--------------
     Dropdown Sub Menu
 ---------------*/

--- a/stories/Menu/vertical.stories.js
+++ b/stories/Menu/vertical.stories.js
@@ -52,6 +52,28 @@ storiesOf('Menu/Vertical', module)
       </React.Fragment>
     )
   })
+  .add('icons only - small', () => {
+    const items = [
+      {
+        icon: 'home'
+      },
+      {
+        icon: 'place'
+      },
+      {
+        icon: 'assignment'
+      }
+    ]
+    return (
+      <React.Fragment>
+        <Menu className="blue" size="small" vertical icon items={items} />
+        <br />
+        <Menu className="pink" size="small" vertical icon items={items} />
+        <br />
+        <Menu className="green" size="small" vertical icon items={items} />
+      </React.Fragment>
+    )
+  })
 
 storiesOf('Menu/Vertical/SubMenus/Internal', module)
   .add('closed', () => (


### PR DESCRIPTION
We can now have two different sizes of vertical icons-only menus:

**Default:**
<img width="119" alt="screen shot 2019-01-07 at 2 39 11 pm" src="https://user-images.githubusercontent.com/5216049/50783589-19412f80-128a-11e9-890f-c9e5bcb3aec5.png">

**Small**
<img width="140" alt="screen shot 2019-01-07 at 2 39 04 pm" src="https://user-images.githubusercontent.com/5216049/50783588-19412f80-128a-11e9-88e2-3a50dc16172e.png">
