### PR TITLE
Add new WizardFooter component with steps as breadcrumbs

### DIFF
--- a/components/Wizard/Footer/BasicControls.js
+++ b/components/Wizard/Footer/BasicControls.js
@@ -1,0 +1,78 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { Button } from 'semantic-ui-react'
+
+class WizardFooterBasicControls extends Component {
+  static propTypes = {
+    currentStep: PropTypes.number.isRequired,
+    labels: PropTypes.shape({
+      cancel: PropTypes.string,
+      prev: PropTypes.string,
+      save: PropTypes.string,
+      next: PropTypes.string,
+      finish: PropTypes.string
+    }),
+    onCancel: PropTypes.func,
+    onChangeStep: PropTypes.func.isRequired,
+    onFinish: PropTypes.func,
+    onSave: PropTypes.func,
+    showSaveButton: PropTypes.bool,
+    totalSteps: PropTypes.number.isRequired
+  }
+
+  static defaultProps = {
+    labels: {
+      cancel: 'Cancel',
+      prev: 'Previous',
+      save: 'Save',
+      next: 'Next',
+      finish: 'Finish'
+    }
+  }
+
+  render() {
+    const {
+      currentStep,
+      labels,
+      onCancel,
+      onFinish,
+      onSave,
+      showSaveButton,
+      totalSteps
+    } = this.props
+    const isLastStep = currentStep === totalSteps - 1
+    return (
+      <React.Fragment>
+        <Button onClick={onCancel}>{labels.cancel}</Button>
+        {currentStep > 0 && (
+          <Button onClick={this.handlePrevious}>{labels.prev}</Button>
+        )}
+        {showSaveButton &&
+          !isLastStep && <Button onClick={onSave}>{labels.save}</Button>}
+        {!isLastStep && (
+          <Button className="blue" onClick={this.handleNext}>
+            {labels.next}
+          </Button>
+        )}
+        {isLastStep && (
+          <Button className="blue" onClick={onFinish}>
+            {labels.finish}
+          </Button>
+        )}
+      </React.Fragment>
+    )
+  }
+
+  handleNext = () => {
+    const { currentStep, onChangeStep } = this.props
+    onChangeStep(currentStep + 1)
+  }
+
+  handlePrevious = () => {
+    const { currentStep, onChangeStep } = this.props
+    onChangeStep(currentStep - 1)
+  }
+}
+
+export default WizardFooterBasicControls

--- a/components/Wizard/Footer/__tests__/WizardFooter.test.js
+++ b/components/Wizard/Footer/__tests__/WizardFooter.test.js
@@ -1,0 +1,44 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import WizardFooter from '../'
+
+const buildWrapper = props =>
+  shallow(
+    <WizardFooter
+      controls={jest.fn().mockReturnValue(<div>Test Controls</div>)}
+      onChangeStep={jest.fn()}
+      steps={['Step 1', 'Step 2', 'Step 3']}
+      {...props}
+    />
+  )
+
+describe('WizardFooter', () => {
+  it('should render wizard with given content', () => {
+    expect(buildWrapper()).toMatchSnapshot()
+  })
+
+  describe('when the current step changes', () => {
+    let wrapper
+
+    beforeEach(() => {
+      wrapper = buildWrapper()
+      const {
+        props: { controls }
+      } = wrapper.instance()
+      const { onChangeStep } = controls.mock.calls[0][0]
+      onChangeStep(1)
+    })
+
+    it('should render the new step as the current step', () => {
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it('should call "onChangeStep" prop with the new step', () => {
+      const {
+        props: { onChangeStep }
+      } = wrapper.instance()
+      expect(onChangeStep).toHaveBeenCalledWith(1)
+    })
+  })
+})

--- a/components/Wizard/Footer/__tests__/WizardFooterBasicControls.test.js
+++ b/components/Wizard/Footer/__tests__/WizardFooterBasicControls.test.js
@@ -1,0 +1,86 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import { Button } from 'semantic-ui-react'
+
+import WizardFooterBasicControls from '../BasicControls'
+
+const buildWrapper = props =>
+  shallow(
+    <WizardFooterBasicControls
+      currentStep={1}
+      onChangeStep={jest.fn()}
+      totalSteps={3}
+      {...props}
+    />
+  )
+
+describe('WizardFooterBasicControls', () => {
+  it('should render "cancel", "previous" and "next" buttons', () => {
+    expect(buildWrapper()).toMatchSnapshot()
+  })
+
+  describe('when the current step is the first step', () => {
+    it('should render "cancel" and "next" buttons', () => {
+      const wrapper = buildWrapper({ currentStep: 0 })
+      expect(wrapper).toMatchSnapshot()
+    })
+  })
+
+  describe('when the current step is the last step', () => {
+    it('should render "cancel", "previous" and "finish" buttons', () => {
+      const wrapper = buildWrapper({ currentStep: 2 })
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it('should call the "onFinish" prop when the "finish" button is clicked', () => {
+      const onFinish = jest.fn()
+      const wrapper = buildWrapper({ currentStep: 2, onFinish })
+      const button = wrapper.find(Button).at(2)
+      button.simulate('click')
+      expect(onFinish).toHaveBeenCalled()
+    })
+  })
+
+  describe('when the "showSaveButton" prop is set to "true"', () => {
+    it('should render "cancel", "previous", "save" and "next" buttons', () => {
+      const wrapper = buildWrapper({ showSaveButton: true })
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it('should call the "onSave" prop when the "save" button is clicked', () => {
+      const onSave = jest.fn()
+      const wrapper = buildWrapper({ showSaveButton: true, onSave })
+      const button = wrapper.find(Button).at(2)
+      button.simulate('click')
+      expect(onSave).toHaveBeenCalled()
+    })
+  })
+
+  describe('when the "next" button is clicked', () => {
+    it('should call "onChangeStep" with the next step index', () => {
+      const onChangeStep = jest.fn()
+      const wrapper = buildWrapper({ onChangeStep })
+      const button = wrapper.find(Button).at(2)
+      button.simulate('click')
+      expect(onChangeStep).toHaveBeenCalledWith(2)
+    })
+  })
+
+  describe('when the "previous" button is clicked', () => {
+    it('should call "onChangeStep" with the previous step index', () => {
+      const onChangeStep = jest.fn()
+      const wrapper = buildWrapper({ onChangeStep })
+      const button = wrapper.find(Button).at(1)
+      button.simulate('click')
+      expect(onChangeStep).toHaveBeenCalledWith(0)
+    })
+  })
+
+  it('should call the "onCancel" prop when the "cancel" button is clicked', () => {
+    const onCancel = jest.fn()
+    const wrapper = buildWrapper({ onCancel })
+    const button = wrapper.find(Button).at(0)
+    button.simulate('click')
+    expect(onCancel).toHaveBeenCalled()
+  })
+})

--- a/components/Wizard/Footer/__tests__/__snapshots__/WizardFooter.test.js.snap
+++ b/components/Wizard/Footer/__tests__/__snapshots__/WizardFooter.test.js.snap
@@ -1,0 +1,87 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WizardFooter should render wizard with given content 1`] = `
+<div
+  className="inloco-wizard__footer"
+>
+  <Breadcrumb>
+    <BreadcrumbSection
+      className="inloco-wizard__footer-step--current"
+    >
+      Step 1
+    </BreadcrumbSection>
+    <BreadcrumbDivider>
+      <Icon
+        as="i"
+        className="chevron right"
+      />
+    </BreadcrumbDivider>
+    <BreadcrumbSection
+      className=""
+    >
+      Step 2
+    </BreadcrumbSection>
+    <BreadcrumbDivider>
+      <Icon
+        as="i"
+        className="chevron right"
+      />
+    </BreadcrumbDivider>
+    <BreadcrumbSection
+      className=""
+    >
+      Step 3
+    </BreadcrumbSection>
+  </Breadcrumb>
+  <div
+    className="inloco-wizard__footer-controls"
+  >
+    <div>
+      Test Controls
+    </div>
+  </div>
+</div>
+`;
+
+exports[`WizardFooter when the current step changes should render the new step as the current step 1`] = `
+<div
+  className="inloco-wizard__footer"
+>
+  <Breadcrumb>
+    <BreadcrumbSection
+      className=""
+    >
+      Step 1
+    </BreadcrumbSection>
+    <BreadcrumbDivider>
+      <Icon
+        as="i"
+        className="chevron right"
+      />
+    </BreadcrumbDivider>
+    <BreadcrumbSection
+      className="inloco-wizard__footer-step--current"
+    >
+      Step 2
+    </BreadcrumbSection>
+    <BreadcrumbDivider>
+      <Icon
+        as="i"
+        className="chevron right"
+      />
+    </BreadcrumbDivider>
+    <BreadcrumbSection
+      className=""
+    >
+      Step 3
+    </BreadcrumbSection>
+  </Breadcrumb>
+  <div
+    className="inloco-wizard__footer-controls"
+  >
+    <div>
+      Test Controls
+    </div>
+  </div>
+</div>
+`;

--- a/components/Wizard/Footer/__tests__/__snapshots__/WizardFooterBasicControls.test.js.snap
+++ b/components/Wizard/Footer/__tests__/__snapshots__/WizardFooterBasicControls.test.js.snap
@@ -1,0 +1,103 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`WizardFooterBasicControls should render "cancel", "previous" and "next" buttons 1`] = `
+<Fragment>
+  <Button
+    as="button"
+    role="button"
+  >
+    Cancel
+  </Button>
+  <Button
+    as="button"
+    onClick={[Function]}
+    role="button"
+  >
+    Previous
+  </Button>
+  <Button
+    as="button"
+    className="blue"
+    onClick={[Function]}
+    role="button"
+  >
+    Next
+  </Button>
+</Fragment>
+`;
+
+exports[`WizardFooterBasicControls when the "showSaveButton" prop is set to "true" should render "cancel", "previous", "save" and "next" buttons 1`] = `
+<Fragment>
+  <Button
+    as="button"
+    role="button"
+  >
+    Cancel
+  </Button>
+  <Button
+    as="button"
+    onClick={[Function]}
+    role="button"
+  >
+    Previous
+  </Button>
+  <Button
+    as="button"
+    role="button"
+  >
+    Save
+  </Button>
+  <Button
+    as="button"
+    className="blue"
+    onClick={[Function]}
+    role="button"
+  >
+    Next
+  </Button>
+</Fragment>
+`;
+
+exports[`WizardFooterBasicControls when the current step is the first step should render "cancel" and "next" buttons 1`] = `
+<Fragment>
+  <Button
+    as="button"
+    role="button"
+  >
+    Cancel
+  </Button>
+  <Button
+    as="button"
+    className="blue"
+    onClick={[Function]}
+    role="button"
+  >
+    Next
+  </Button>
+</Fragment>
+`;
+
+exports[`WizardFooterBasicControls when the current step is the last step should render "cancel", "previous" and "finish" buttons 1`] = `
+<Fragment>
+  <Button
+    as="button"
+    role="button"
+  >
+    Cancel
+  </Button>
+  <Button
+    as="button"
+    onClick={[Function]}
+    role="button"
+  >
+    Previous
+  </Button>
+  <Button
+    as="button"
+    className="blue"
+    role="button"
+  >
+    Finish
+  </Button>
+</Fragment>
+`;

--- a/components/Wizard/Footer/index.js
+++ b/components/Wizard/Footer/index.js
@@ -1,0 +1,73 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+import { Breadcrumb, Icon } from 'semantic-ui-react'
+
+class WizardFooter extends Component {
+  static propTypes = {
+    className: PropTypes.string,
+    controls: PropTypes.func.isRequired,
+    initialStepIndex: PropTypes.number,
+    onChangeStep: PropTypes.func,
+    steps: PropTypes.arrayOf(PropTypes.string).isRequired
+  }
+
+  static defaultProps = {
+    initialStepIndex: 0,
+    onChangeStep: () => {}
+  }
+
+  state = {
+    currentStep: this.props.initialStepIndex
+  }
+
+  render() {
+    const {
+      controls,
+      className,
+      initialStepIndex,
+      onChangeStep,
+      steps,
+      ...otherProps
+    } = this.props
+    const { currentStep } = this.state
+    const classes = cx('inloco-wizard__footer', className)
+    return (
+      <div className={classes} {...otherProps}>
+        <Breadcrumb>
+          {steps.map((step, index) => {
+            const sectionClasses = cx({
+              'inloco-wizard__footer-step--current': currentStep === index
+            })
+            return (
+              <React.Fragment key={step}>
+                {index !== 0 && (
+                  <Breadcrumb.Divider>
+                    <Icon className="chevron right" />
+                  </Breadcrumb.Divider>
+                )}
+                <Breadcrumb.Section className={sectionClasses}>
+                  {step}
+                </Breadcrumb.Section>
+              </React.Fragment>
+            )
+          })}
+        </Breadcrumb>
+        <div className="inloco-wizard__footer-controls">
+          {controls({
+            currentStep,
+            onChangeStep: this.handleChangeStep
+          })}
+        </div>
+      </div>
+    )
+  }
+
+  handleChangeStep = newStepIndex => {
+    this.setState({ currentStep: newStepIndex })
+    this.props.onChangeStep(newStepIndex)
+  }
+}
+
+export default WizardFooter

--- a/components/Wizard/__tests__/Wizard.test.js
+++ b/components/Wizard/__tests__/Wizard.test.js
@@ -1,0 +1,12 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import Wizard from '../'
+
+const buildWrapper = props => shallow(<Wizard>Test Children Content</Wizard>)
+
+describe('Wizard', () => {
+  it('should render wizard with given content', () => {
+    expect(buildWrapper()).toMatchSnapshot()
+  })
+})

--- a/components/Wizard/__tests__/__snapshots__/Wizard.test.js.snap
+++ b/components/Wizard/__tests__/__snapshots__/Wizard.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`Wizard should render wizard with given content 1`] = `
+<div
+  className="inloco-wizard"
+>
+  Test Children Content
+</div>
+`;

--- a/components/Wizard/index.js
+++ b/components/Wizard/index.js
@@ -1,0 +1,28 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+import WizardFooter from './Footer'
+import WizardFooterBasicControls from './Footer/BasicControls'
+
+export class Wizard extends Component {
+  static propTypes = {
+    className: PropTypes.string,
+    children: PropTypes.node.isRequired
+  }
+
+  static Footer = WizardFooter
+  static FooterBasicControls = WizardFooterBasicControls
+
+  render() {
+    const { children, className, ...otherProps } = this.props
+    const classes = cx('inloco-wizard', className)
+    return (
+      <div className={classes} {...otherProps}>
+        {children}
+      </div>
+    )
+  }
+}
+
+export default Wizard

--- a/components/index.js
+++ b/components/index.js
@@ -1,3 +1,4 @@
 export * from 'semantic-ui-react'
 export * from './RemovableLabel'
 export * from './Layout'
+export * from './Wizard'

--- a/semantic.json
+++ b/semantic.json
@@ -69,7 +69,8 @@
     "form",
     "state",
     "visibility",
-    "layout"
+    "layout",
+    "wizard"
   ],
   "version": "2.4.2"
 }

--- a/src/definitions/inloco/wizard.less
+++ b/src/definitions/inloco/wizard.less
@@ -1,0 +1,54 @@
+/*******************************
+            Wizard
+*******************************/
+
+/*******************************
+            Theme
+*******************************/
+
+@type : 'collection';
+@element : 'menu';
+
+@import (multiple) '../../theme.config';
+
+/*--------------
+    Wizard Footer
+---------------*/
+
+.inloco-wizard__footer {
+  align-items: center;
+  background-color: #fff;
+  box-shadow: 0 -2px 3px -2px fade(@n600, 5%);
+  display: flex;
+  height: 68px;
+  justify-content: space-between;
+  padding: 0 32px;
+
+  .ui.breadcrumb {
+    .section {
+      color: fade(@gray800, 50%);
+      font-size: 10px;
+      height: 20px;
+      line-height: 20px;
+
+      &.inloco-wizard__footer-step--current {
+        color: fade(@gray800, 88%);
+        font-size: 14px;
+      }
+    }
+
+    .divider {
+      color: fade(@n200, 88%);
+      font-size: 16px;
+      height: 20px;
+      line-height: 20px;
+      vertical-align: middle;
+    }
+  }
+}
+
+.inloco-wizard__footer-controls {
+  .button {
+    margin-left: 16px;
+  }
+}

--- a/src/semantic.less
+++ b/src/semantic.less
@@ -162,3 +162,6 @@
 & {
   @import 'definitions/inloco/layout';
 }
+& {
+  @import 'definitions/inloco/wizard';
+}

--- a/stories/Wizard/index.stories.js
+++ b/stories/Wizard/index.stories.js
@@ -1,0 +1,11 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import { Button, Wizard } from '../../components'
+
+storiesOf('Wizard', module).add('footer', () => (
+  <Wizard.Footer
+    controls={props => <Wizard.FooterBasicControls {...props} totalSteps={3} />}
+    steps={['First Step', 'Second Step', 'Third Step']}
+  />
+))


### PR DESCRIPTION
I've created the structure for the new `<Wizard>` component, which includes: js files, less file, story file.

The main `Wizard` component will be able to receive multiple step components and a footer with controls. I haven't implemented the `Wizard` component yet, it's going to be added on a next pull request. Here, besides the structure, I've focused on the `Wizard.Footer`.

The design Bruno gave me is very similar to what is being used today on the Ads product, but with a few differences. The main difference is that the steps aren't shown as a progress bar, but as breadcrumbs instead. I've asked Bruno if I should leave this more flexible and he said that the idea is for Ads to use the breadcrumbs too soon, so I'm having `Wizard.Footer` use them directly. We can always make that more flexible later if needed though.

As for the buttons, I've left `Wizard.Footer` more flexible, since this part can change more frequently. The component has a `controls` render prop that can be used to define the buttons, so it's fully customizable. I've also created a `Wizard.FooterBasicControls` component with the most common set of buttons, so that this case won't end up being duplicated everywhere.

See it in action:
![wizard footer](https://duaw26jehqd4r.cloudfront.net/items/2b340s2A0a202l193T1c/Screen%20Recording%202019-01-14%20at%2004.10%20PM.gif)

 