### PR TITLE
Create form validator components

### DIFF
--- a/components/FormValidator/Context.js
+++ b/components/FormValidator/Context.js
@@ -1,0 +1,5 @@
+import React from 'react'
+
+const LayoutContext = React.createContext('inloco-form-validator')
+
+export default LayoutContext

--- a/components/FormValidator/Field.js
+++ b/components/FormValidator/Field.js
@@ -1,0 +1,35 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { Form } from 'semantic-ui-react'
+
+import FormValidatorContext from './Context'
+import FormValidatorMessage from './Message'
+
+export class FormValidatorField extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+    name: PropTypes.string.isRequired
+  }
+
+  static contextType = FormValidatorContext
+
+  render() {
+    const { children, className, name, ...otherProps } = this.props
+    const { errors = {} } = this.context
+    const classes = cx('inloco-form-validator__field', className)
+    return (
+      <Form.Field
+        className={classes}
+        name={name}
+        error={!!errors[name]}
+        {...otherProps}>
+        {children}
+        <FormValidatorMessage message={errors[name]} />
+      </Form.Field>
+    )
+  }
+}
+
+export default FormValidatorField

--- a/components/FormValidator/Message.js
+++ b/components/FormValidator/Message.js
@@ -1,0 +1,22 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+
+export class FormValidatorMessage extends Component {
+  static propTypes = {
+    className: PropTypes.string,
+    message: PropTypes.string
+  }
+
+  render() {
+    const { className, message, ...otherProps } = this.props
+    const classes = cx('inloco-form-validator__field', className)
+    return (
+      <div className={classes} {...otherProps}>
+        {message}
+      </div>
+    )
+  }
+}
+
+export default FormValidatorMessage

--- a/components/FormValidator/Message.js
+++ b/components/FormValidator/Message.js
@@ -1,6 +1,7 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
+import { Icon } from 'semantic-ui-react'
 
 export class FormValidatorMessage extends Component {
   static propTypes = {
@@ -10,9 +11,10 @@ export class FormValidatorMessage extends Component {
 
   render() {
     const { className, message, ...otherProps } = this.props
-    const classes = cx('inloco-form-validator__field', className)
+    const classes = cx('inloco-form-validator__message', className)
     return (
       <div className={classes} {...otherProps}>
+        {message && <Icon className="error" size="big" />}
         {message}
       </div>
     )

--- a/components/FormValidator/__tests__/FormValidator.test.js
+++ b/components/FormValidator/__tests__/FormValidator.test.js
@@ -10,15 +10,15 @@ const buildWrapper = props =>
       className="test-class"
       onSubmit={jest.fn()}
       onSubmitSuccess={jest.fn()}
-      rules={{
-        name: {
-          message: 'Name is required',
-          validate: value => value
-        },
-        age: {
-          message: 'Age should be an integer',
-          validate: value => Number.isInteger(value)
+      validate={({ age, name }) => {
+        const errors = {}
+        if (!name) {
+          errors.name = 'Name is required'
         }
+        if (!Number.isInteger(age)) {
+          errors.age = 'Age should be an integer'
+        }
+        return errors
       }}
       value={{
         age: 29

--- a/components/FormValidator/__tests__/FormValidator.test.js
+++ b/components/FormValidator/__tests__/FormValidator.test.js
@@ -1,0 +1,69 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+import { Form } from 'semantic-ui-react'
+
+import FormValidator from '../'
+
+const buildWrapper = props =>
+  shallow(
+    <FormValidator
+      className="test-class"
+      onSubmit={jest.fn()}
+      onSubmitSuccess={jest.fn()}
+      rules={{
+        name: {
+          message: 'Name is required',
+          validate: value => value
+        },
+        age: {
+          message: 'Age should be an integer',
+          validate: value => Number.isInteger(value)
+        }
+      }}
+      value={{
+        age: 29
+      }}
+      {...props}>
+      Test Children Content
+    </FormValidator>
+  )
+
+describe('FormValidator', () => {
+  it('should render form and context provider with no errors at first', () => {
+    expect(buildWrapper()).toMatchSnapshot()
+  })
+
+  describe('when the form is submitted', () => {
+    let wrapper
+
+    beforeEach(() => {
+      wrapper = buildWrapper()
+      wrapper.find(Form).simulate('submit')
+    })
+
+    it('should render a context provider with the validation errors', () => {
+      expect(wrapper).toMatchSnapshot()
+    })
+
+    it('should call "onSubmit" prop', () => {
+      const {
+        props: { onSubmit }
+      } = wrapper.instance()
+      expect(onSubmit).toHaveBeenCalled()
+    })
+
+    describe('when the "value" changes', () => {
+      it('should clear existing errors that were resolved', () => {
+        wrapper.setProps({
+          value: { name: 'Maira', age: 29 }
+        })
+        expect(wrapper).toMatchSnapshot()
+      })
+
+      it('should not show new errors', () => {
+        wrapper.setProps({ value: { age: 'String age?' } })
+        expect(wrapper).toMatchSnapshot()
+      })
+    })
+  })
+})

--- a/components/FormValidator/__tests__/FormValidatorMessage.test.js
+++ b/components/FormValidator/__tests__/FormValidatorMessage.test.js
@@ -1,0 +1,19 @@
+import { shallow } from 'enzyme'
+import React from 'react'
+
+import FormValidatorMessage from '../Message'
+
+const buildWrapper = props =>
+  shallow(
+    <FormValidatorMessage
+      className="test-class"
+      message="Custom message"
+      {...props}
+    />
+  )
+
+describe('FormValidatorMessage', () => {
+  it('should render the message', () => {
+    expect(buildWrapper()).toMatchSnapshot()
+  })
+})

--- a/components/FormValidator/__tests__/__snapshots__/FormValidator.test.js.snap
+++ b/components/FormValidator/__tests__/__snapshots__/FormValidator.test.js.snap
@@ -28,7 +28,6 @@ exports[`FormValidator when the form is submitted should render a context provid
     value={
       Object {
         "errors": Object {
-          "age": undefined,
           "name": "Name is required",
         },
       }
@@ -69,7 +68,6 @@ exports[`FormValidator when the form is submitted when the "value" changes shoul
     value={
       Object {
         "errors": Object {
-          "age": undefined,
           "name": "Name is required",
         },
       }

--- a/components/FormValidator/__tests__/__snapshots__/FormValidator.test.js.snap
+++ b/components/FormValidator/__tests__/__snapshots__/FormValidator.test.js.snap
@@ -1,0 +1,81 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormValidator should render form and context provider with no errors at first 1`] = `
+<Form
+  as="form"
+  className="inloco-form-validator test-class"
+  onSubmit={[Function]}
+>
+  <ContextProvider
+    value={
+      Object {
+        "errors": Object {},
+      }
+    }
+  >
+    Test Children Content
+  </ContextProvider>
+</Form>
+`;
+
+exports[`FormValidator when the form is submitted should render a context provider with the validation errors 1`] = `
+<Form
+  as="form"
+  className="inloco-form-validator test-class"
+  onSubmit={[Function]}
+>
+  <ContextProvider
+    value={
+      Object {
+        "errors": Object {
+          "age": undefined,
+          "name": "Name is required",
+        },
+      }
+    }
+  >
+    Test Children Content
+  </ContextProvider>
+</Form>
+`;
+
+exports[`FormValidator when the form is submitted when the "value" changes should clear existing errors that were resolved 1`] = `
+<Form
+  as="form"
+  className="inloco-form-validator test-class"
+  onSubmit={[Function]}
+>
+  <ContextProvider
+    value={
+      Object {
+        "errors": Object {
+          "name": undefined,
+        },
+      }
+    }
+  >
+    Test Children Content
+  </ContextProvider>
+</Form>
+`;
+
+exports[`FormValidator when the form is submitted when the "value" changes should not show new errors 1`] = `
+<Form
+  as="form"
+  className="inloco-form-validator test-class"
+  onSubmit={[Function]}
+>
+  <ContextProvider
+    value={
+      Object {
+        "errors": Object {
+          "age": undefined,
+          "name": "Name is required",
+        },
+      }
+    }
+  >
+    Test Children Content
+  </ContextProvider>
+</Form>
+`;

--- a/components/FormValidator/__tests__/__snapshots__/FormValidatorMessage.test.js.snap
+++ b/components/FormValidator/__tests__/__snapshots__/FormValidatorMessage.test.js.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`FormValidatorMessage should render the message 1`] = `
+<div
+  className="inloco-form-validator__field test-class"
+>
+  Custom message
+</div>
+`;

--- a/components/FormValidator/__tests__/__snapshots__/FormValidatorMessage.test.js.snap
+++ b/components/FormValidator/__tests__/__snapshots__/FormValidatorMessage.test.js.snap
@@ -2,8 +2,13 @@
 
 exports[`FormValidatorMessage should render the message 1`] = `
 <div
-  className="inloco-form-validator__field test-class"
+  className="inloco-form-validator__message test-class"
 >
+  <Icon
+    as="i"
+    className="error"
+    size="big"
+  />
   Custom message
 </div>
 `;

--- a/components/FormValidator/index.js
+++ b/components/FormValidator/index.js
@@ -4,6 +4,8 @@ import React, { Component } from 'react'
 import { Form } from 'semantic-ui-react'
 
 import FormValidatorContext from './Context'
+import FormValidatorField from './Field'
+import FormValidatorMessage from './Message'
 
 export class FormValidator extends Component {
   static propTypes = {
@@ -16,6 +18,8 @@ export class FormValidator extends Component {
   }
 
   static Context = FormValidatorContext
+  static Field = FormValidatorField
+  static Message = FormValidatorMessage
 
   state = {
     errors: {}
@@ -93,7 +97,7 @@ export class FormValidator extends Component {
 
   runRules(fieldNames) {
     const errorsArray = fieldNames.map(this.runRule)
-    const success = errorsArray.filter(error => !!error).length > 0
+    const success = errorsArray.filter(error => !!error).length === 0
 
     const errors = {}
     fieldNames.forEach(

--- a/components/FormValidator/index.js
+++ b/components/FormValidator/index.js
@@ -1,0 +1,114 @@
+import cx from 'classnames'
+import PropTypes from 'prop-types'
+import React, { Component } from 'react'
+import { Form } from 'semantic-ui-react'
+
+import FormValidatorContext from './Context'
+
+export class FormValidator extends Component {
+  static propTypes = {
+    children: PropTypes.node,
+    className: PropTypes.string,
+    onSubmit: PropTypes.func,
+    onSubmitSuccess: PropTypes.func,
+    rules: PropTypes.object.isRequired,
+    value: PropTypes.object.isRequired
+  }
+
+  static Context = FormValidatorContext
+
+  state = {
+    errors: {}
+  }
+
+  render() {
+    const {
+      children,
+      className,
+      onSubmitSuccess,
+      rules,
+      value,
+      ...otherProps
+    } = this.props
+    const { errors } = this.state
+    const classes = cx('inloco-form-validator', className)
+    return (
+      <Form className={classes} {...otherProps} onSubmit={this.handleSubmit}>
+        <FormValidatorContext.Provider value={{ errors }}>
+          {children}
+        </FormValidatorContext.Provider>
+      </Form>
+    )
+  }
+
+  componentDidUpdate() {
+    if (this.hasErrors()) {
+      this.revalidateExistingErrors()
+    }
+  }
+
+  getFieldsWithError() {
+    const { errors } = this.state
+    return Object.keys(errors).filter(fieldName => errors[fieldName])
+  }
+
+  hasErrors() {
+    return this.getFieldsWithError().length > 0
+  }
+
+  handleSubmit = (...args) => {
+    const { onSubmit, onSubmitSuccess } = this.props
+    onSubmit && onSubmit(...args)
+
+    const success = this.validateAll()
+    if (success && onSubmitSuccess) {
+      onSubmitSuccess()
+    }
+  }
+
+  revalidateExistingErrors() {
+    const { errors } = this.state
+
+    const fieldsWithError = this.getFieldsWithError()
+    const { errors: newErrors } = this.runRules(fieldsWithError)
+
+    const haveErrorsChanged = fieldsWithError.some(
+      fieldName => errors[fieldName] !== newErrors[fieldName]
+    )
+    if (haveErrorsChanged) {
+      this.setState({ errors: newErrors })
+    }
+  }
+
+  runRule = fieldName => {
+    const { rules, value } = this.props
+    const rule = rules[fieldName]
+
+    if (!rule.validate(value[fieldName])) {
+      return typeof rule.message === 'function'
+        ? rule.message({ fieldName })
+        : rule.message
+    }
+  }
+
+  runRules(fieldNames) {
+    const errorsArray = fieldNames.map(this.runRule)
+    const success = errorsArray.filter(error => !!error).length > 0
+
+    const errors = {}
+    fieldNames.forEach(
+      (fieldName, index) => (errors[fieldName] = errorsArray[index])
+    )
+
+    return { errors, success }
+  }
+
+  validateAll() {
+    const allFields = Object.keys(this.props.rules)
+    const { errors, success } = this.runRules(allFields)
+    this.setState({ errors })
+    return success
+  }
+}
+
+export default FormValidator

--- a/components/index.js
+++ b/components/index.js
@@ -1,4 +1,5 @@
 export * from 'semantic-ui-react'
+export * from './FormValidator'
 export * from './RemovableLabel'
 export * from './Layout'
 export * from './Wizard'

--- a/package.json
+++ b/package.json
@@ -60,6 +60,9 @@
     }
   },
   "jest": {
+    "testMatch": [
+      "<rootDir>/components/**/?(*.)(spec|test).js?(x)"
+    ],
     "reporters": [
       "default",
       [

--- a/src/site/collections/form.overrides
+++ b/src/site/collections/form.overrides
@@ -1,3 +1,49 @@
 /*******************************
          Site Overrides
 *******************************/
+
+/*--------------
+    Error
+---------------*/
+
+.ui.form .fields.error .field label,
+.ui.form .field.error label,
+.ui.form .fields.error .field .input,
+.ui.form .field.error .input {
+  color: @labelColor !important;
+}
+
+.ui.form .field.error input {
+  color: @inputColor !important;
+}
+
+.ui.form .field.error .ui.labeled.input {
+  border: 1px solid @formErrorBorder;
+
+  input {
+    border: none;
+
+    &:focus {
+      box-shadow: @inputErrorFocusBoxShadow;
+    }
+  }
+}
+
+.inloco-form-validator {
+  .inloco-form-validator__field.field {
+    margin-bottom: 12px;
+  }
+}
+
+.inloco-form-validator__message {
+  align-items: center;
+  color: @red;
+  display: flex;
+  font-size: 11px;
+  height: 24px;
+  line-height: 1em;
+
+  .icon {
+    margin-right: 6px;
+  }
+}

--- a/src/site/collections/form.variables
+++ b/src/site/collections/form.variables
@@ -4,13 +4,32 @@
 
 @rowDistance: 24px;
 
+@inputColor: @textColor;
+
 @labelFontSize: 12px;
 @labelFontWeight: 400;
 @labelColor: rgba(97,98,99, .88);
 @labelMargin: 0 0 8px;
 
-@inputFocusBoxShadow: 0 0 0px 1px rgba(62, 73, 101, .5);
+@inputFocusBoxShadow: 0 0 0px 1px fade(@n600, 50%);
 @inputTransition:
     color .2s cubic-bezier(.64,0,.35,1),
     border-color .2s cubic-bezier(.64,0,.35,1),
     box-shadow .2s cubic-bezier(.64,0,.35,1);
+
+/*--------------
+    Error
+---------------*/
+
+@inputErrorPlaceholderColor: @inputPlaceholderColor;
+@inputErrorPlaceholderFocusColor: @inputPlaceholderColor;
+
+@formErrorColor: @red;
+
+@formErrorBackground: @gray00;
+@inputErrorFocusBackground: @formErrorBackground;
+
+@formErrorBorder: fade(@red, 50%);
+@inputErrorFocusBorder: @formErrorBorder;
+
+@inputErrorFocusBoxShadow: 0 0 0px 1px fade(@red, 50%);

--- a/src/site/globals/site.variables
+++ b/src/site/globals/site.variables
@@ -89,7 +89,7 @@
 @greenFocus       : #A2C204;
 @greenDown        : #98B200;
 
-@red        : @alertRed;
+@red        : @alertRed; // RGB: 217, 36, 0
 @yellow     : @alertYellow;
 
 @linkColor           : @blue;

--- a/stories/FormValidator/validation.stories.js
+++ b/stories/FormValidator/validation.stories.js
@@ -1,0 +1,25 @@
+import React from 'react'
+import { storiesOf } from '@storybook/react'
+
+import { Button, Checkbox, Input, Form } from '../../components'
+
+storiesOf('FormValidator', module).add('basic', () => (
+  <Form>
+    <Form.Field error>
+      <label>First Name</label>
+      <Input placeholder="First Name" />
+    </Form.Field>
+    <Form.Field>
+      <label>Last Name</label>
+      <Input placeholder="Last Name" />
+    </Form.Field>
+    <Form.Field>
+      <label>Website</label>
+      <Input placeholder="Website" label="https://" />
+    </Form.Field>
+    <Form.Field>
+      <Checkbox className="blue" label="I agree to the Terms and Conditions" />
+    </Form.Field>
+    <Button type="submit">Submit</Button>
+  </Form>
+))

--- a/stories/FormValidator/validation.stories.js
+++ b/stories/FormValidator/validation.stories.js
@@ -1,25 +1,86 @@
-import React from 'react'
+import React, { Component } from 'react'
 import { storiesOf } from '@storybook/react'
+import { action } from '@storybook/addon-actions'
 
-import { Button, Checkbox, Input, Form } from '../../components'
+import { Button, Checkbox, Input, FormValidator } from '../../components'
 
-storiesOf('FormValidator', module).add('basic', () => (
-  <Form>
-    <Form.Field error>
-      <label>First Name</label>
-      <Input placeholder="First Name" />
-    </Form.Field>
-    <Form.Field>
-      <label>Last Name</label>
-      <Input placeholder="Last Name" />
-    </Form.Field>
-    <Form.Field>
-      <label>Website</label>
-      <Input placeholder="Website" label="https://" />
-    </Form.Field>
-    <Form.Field>
-      <Checkbox className="blue" label="I agree to the Terms and Conditions" />
-    </Form.Field>
-    <Button type="submit">Submit</Button>
-  </Form>
-))
+const RULES = {
+  firstName: {
+    message: 'The first name is required.',
+    validate: value => value
+  },
+  lastName: {
+    message: 'The last name is required.',
+    validate: value => value
+  },
+  website: {
+    message: 'The website is required and must have at least one dot (".").',
+    validate: value => value && value.includes('.')
+  },
+  terms: {
+    message: 'The terms must be accepted.',
+    validate: value => value
+  }
+}
+
+class ExampleForm extends Component {
+  state = {
+    value: {}
+  }
+
+  render() {
+    const { value } = this.state
+    return (
+      <FormValidator
+        rules={RULES}
+        value={value}
+        onSubmitSuccess={action('Valid form submission!')}>
+        <FormValidator.Field name="firstName">
+          <label>First Name</label>
+          <Input
+            placeholder="First Name"
+            name="firstName"
+            onChange={this.handleChange}
+          />
+        </FormValidator.Field>
+        <FormValidator.Field name="lastName">
+          <label>Last Name</label>
+          <Input
+            placeholder="Last Name"
+            name="lastName"
+            onChange={this.handleChange}
+          />
+        </FormValidator.Field>
+        <FormValidator.Field name="website">
+          <label>Website</label>
+          <Input
+            placeholder="Website"
+            label="https://"
+            name="website"
+            onChange={this.handleChange}
+          />
+        </FormValidator.Field>
+        <FormValidator.Field name="terms">
+          <Checkbox
+            className="blue"
+            label="I agree to the Terms and Conditions"
+            name="terms"
+            onChange={this.handleChange}
+          />
+        </FormValidator.Field>
+        <Button type="submit">Submit</Button>
+      </FormValidator>
+    )
+  }
+
+  handleChange = (event, data) => {
+    this.setState(({ value }) => ({
+      value: {
+        ...value,
+        [data.name]: data.value || data.checked
+      }
+    }))
+  }
+}
+
+storiesOf('FormValidator', module).add('basic', () => <ExampleForm />)

--- a/stories/FormValidator/validation.stories.js
+++ b/stories/FormValidator/validation.stories.js
@@ -4,23 +4,22 @@ import { action } from '@storybook/addon-actions'
 
 import { Button, Checkbox, Input, FormValidator } from '../../components'
 
-const RULES = {
-  firstName: {
-    message: 'The first name is required.',
-    validate: value => value
-  },
-  lastName: {
-    message: 'The last name is required.',
-    validate: value => value
-  },
-  website: {
-    message: 'The website is required and must have at least one dot (".").',
-    validate: value => value && value.includes('.')
-  },
-  terms: {
-    message: 'The terms must be accepted.',
-    validate: value => value
+const validate = ({ firstName, lastName, website, terms }) => {
+  const errors = {}
+  if (!firstName) {
+    errors.firstName = 'The first name is required.'
   }
+  if (!lastName) {
+    errors.lastName = 'The last name is required.'
+  }
+  if (!website || !website.includes('.')) {
+    errors.website =
+      'The website is required and must have at least one dot (".").'
+  }
+  if (!terms) {
+    errors.terms = 'The terms must be accepted.'
+  }
+  return errors
 }
 
 class ExampleForm extends Component {
@@ -32,7 +31,7 @@ class ExampleForm extends Component {
     const { value } = this.state
     return (
       <FormValidator
-        rules={RULES}
+        validate={validate}
         value={value}
         onSubmitSuccess={action('Valid form submission!')}>
         <FormValidator.Field name="firstName">


### PR DESCRIPTION
Semantic ui doesn't have a form validator built in, so I've created one. Take a look at the new stories file in this pr to see how to use it.

Let me just explain the behavior a little now. Fields will be all validated on form submission and show errors when requested. If there are no errors, the `onSubmitSuccess` prop callback will be fired. Fields with errors are revalidated as the user changes their values, to show when they're valid again.

I've also styled the errors according to what Bruno defined.

![2019-02-14 15 24 12](https://user-images.githubusercontent.com/5216049/52808533-e0585f80-306c-11e9-8fac-84106f417061.gif)
