### PR TITLE
refactor(submenu-dropdown ): open it on hover

### DIFF
--- a/components/Layout/Sidebar/Submenu/Dropdown.js
+++ b/components/Layout/Sidebar/Submenu/Dropdown.js
@@ -14,9 +14,11 @@ class SidebarSubmenuDropdown extends Component {
   }
 
   state = {
-    open: false
+    openWithHover: false,
+    openWithClick: false
   }
 
+  wrapperRef = React.createRef()
   dropdownRef = React.createRef()
 
   render() {
@@ -28,19 +30,22 @@ class SidebarSubmenuDropdown extends Component {
       content,
       ...otherProps
     } = this.props
-    const { open } = this.state
     const classes = cx('inloco-layout__sidebar-submenu-dropdown', className, {
       activeSubMenu: active
     })
 
     return (
-      <div onMouseEnter={this.handleOpen} onMouseLeave={this.handleClose}>
+      <div
+        ref={this.wrapperRef}
+        onClick={this.handleClick}
+        onMouseEnter={this.handleMouseEnter}
+        onMouseLeave={this.handleMouseLeave}>
         <Dropdown
-          ref={this.dropdownRef}
-          className={classes}
           item
+          ref={this.dropdownRef}
+          open={this.isMenuOpen()}
+          className={classes}
           icon={normalizeIconProp(icon)}
-          open={this.state.open}
           {...otherProps}>
           <Dropdown.Menu style={this.getMenuStyle()}>
             <Dropdown.Header content={content} />
@@ -51,6 +56,14 @@ class SidebarSubmenuDropdown extends Component {
         </Dropdown>
       </div>
     )
+  }
+
+  componentDidMount() {
+    document.addEventListener('click', this.handleOutsideClick, true)
+  }
+
+  componentWillUnmount() {
+    document.removeEventListener('click', this.handleOutsideClick, true)
   }
 
   /**
@@ -68,17 +81,46 @@ class SidebarSubmenuDropdown extends Component {
     const dropdownComponent = this.dropdownRef.current
     const dropdownElement = dropdownComponent && dropdownComponent.ref
 
-    return this.state.open && dropdownElement
+    return this.isMenuOpen() && dropdownElement
       ? { top: dropdownElement.getBoundingClientRect().top }
       : null
   }
 
-  handleOpen = () => {
-    this.setState({ open: true })
+  handleClick = () => {
+    if (this.state.openWithClick) {
+      return this.closeMenu()
+    }
+
+    return this.setState({ openWithClick: true })
   }
 
-  handleClose = () => {
-    this.setState({ open: false })
+  handleOutsideClick = event => {
+    const { current: wrapper } = this.wrapperRef
+    const isAnOutsideClick = wrapper && !wrapper.contains(event.target)
+
+    if (!isAnOutsideClick) {
+      return this.handleClick()
+    }
+
+    if (this.isMenuOpen()) {
+      return this.closeMenu()
+    }
+  }
+
+  handleMouseEnter = () => {
+    this.setState({ openWithHover: true })
+  }
+
+  handleMouseLeave = () => {
+    this.setState({ openWithHover: false })
+  }
+
+  closeMenu = () => {
+    this.setState({ openWithClick: false, openWithHover: false })
+  }
+
+  isMenuOpen = () => {
+    return this.state.openWithHover || this.state.openWithClick
   }
 }
 

--- a/components/Layout/Sidebar/Submenu/Dropdown.js
+++ b/components/Layout/Sidebar/Submenu/Dropdown.js
@@ -49,6 +49,11 @@ class SidebarSubmenuDropdown extends Component {
           {...otherProps}>
           <Dropdown.Menu style={this.getMenuStyle()}>
             <Dropdown.Header content={content} />
+            {/**
+             * This invisible element helps to avoid the mouseleave trigger when
+             * the user tries to move the mouse from the trigger to
+             */}
+            <div className="inloco-layout__sidebar-submenu-invisible-item" />
             {React.Children.map(children, child =>
               React.cloneElement(child, { dropdown: true })
             )}

--- a/components/Layout/Sidebar/Submenu/Dropdown.js
+++ b/components/Layout/Sidebar/Submenu/Dropdown.js
@@ -1,7 +1,7 @@
 import cx from 'classnames'
 import PropTypes from 'prop-types'
 import React, { Component } from 'react'
-import { Dropdown, Popup } from 'semantic-ui-react'
+import { Dropdown } from 'semantic-ui-react'
 
 import { normalizeIconProp } from '../../../utils/icons'
 
@@ -33,36 +33,23 @@ class SidebarSubmenuDropdown extends Component {
       activeSubMenu: active
     })
 
-    const dropdown = (
-      <Dropdown
-        ref={this.dropdownRef}
-        className={classes}
-        item
-        icon={normalizeIconProp(icon)}
-        onOpen={this.handleOpen}
-        onClose={this.handleClose}
-        {...otherProps}>
-        <Dropdown.Menu style={this.getMenuStyle()}>
-          <Dropdown.Header content={content} />
-          {React.Children.map(children, child =>
-            React.cloneElement(child, { dropdown: true })
-          )}
-        </Dropdown.Menu>
-      </Dropdown>
-    )
-
-    // We don't want to keep showing the tooltip when the dropdown is
-    // open. This css class is the simplest way of achieving that.
-    const popupClasses = cx({ 'inloco-popup--hidden': open })
     return (
-      <Popup
-        className={popupClasses}
-        inverted
-        size="tiny"
-        position="right center"
-        content={content}
-        trigger={dropdown}
-      />
+      <div onMouseEnter={this.handleOpen} onMouseLeave={this.handleClose}>
+        <Dropdown
+          ref={this.dropdownRef}
+          className={classes}
+          item
+          icon={normalizeIconProp(icon)}
+          open={this.state.open}
+          {...otherProps}>
+          <Dropdown.Menu style={this.getMenuStyle()}>
+            <Dropdown.Header content={content} />
+            {React.Children.map(children, child =>
+              React.cloneElement(child, { dropdown: true })
+            )}
+          </Dropdown.Menu>
+        </Dropdown>
+      </div>
     )
   }
 
@@ -80,6 +67,7 @@ class SidebarSubmenuDropdown extends Component {
   getMenuStyle = () => {
     const dropdownComponent = this.dropdownRef.current
     const dropdownElement = dropdownComponent && dropdownComponent.ref
+
     return this.state.open && dropdownElement
       ? { top: dropdownElement.getBoundingClientRect().top }
       : null

--- a/src/definitions/inloco/layout.less
+++ b/src/definitions/inloco/layout.less
@@ -204,6 +204,14 @@
   }
 }
 
+.inloco-layout__sidebar-submenu-invisible-item {
+  position: absolute;
+  width: 20px;
+  left: -20px;
+  top: 0;
+  height: 100%;
+}
+
 /*--------------
     Layout Topbar
 ---------------*/

--- a/src/definitions/inloco/layout.less
+++ b/src/definitions/inloco/layout.less
@@ -202,45 +202,6 @@
       }
     }
   }
-
-  .inloco-layout__sidebar-submenu.ui.dropdown.item > .menu {
-    background: transparent !important;
-    padding: 0 0 0 12px;
-    margin-left: 0 !important;
-    box-shadow: none;
-  }
-
-  .inloco-layout__sidebar-submenu.ui.dropdown.item > .menu > .header,
-  .inloco-layout__sidebar-submenu.ui.dropdown.item > .menu > .item {
-    background: #fff !important;
-    border-radius: 0px;
-    border-left: 1px solid rgba(0, 0, 0, 0.08);
-    border-right: 1px solid rgba(0, 0, 0, 0.08);
-  }
-
-  .inloco-layout__sidebar-submenu.ui.dropdown.item > .menu > .header {
-    padding: 16px 12px 12px !important;
-    opacity: 1;
-    color: rgba(@gray800, 0.4);
-    border-top: 1px solid rgba(0, 0, 0, 0.08);
-    border-top-left-radius: 3px;
-    border-top-right-radius: 3px;
-  }
-
-  .inloco-layout__sidebar-submenu.ui.dropdown.item > .menu > .item {
-    padding: 8px 12px !important;
-
-    &:hover {
-      background: @n50 !important;
-    }
-
-    &:last-child {
-      border-bottom: 1px solid rgba(0, 0, 0, 0.08);
-      border-bottom-left-radius: 3px;
-      border-bottom-right-radius: 3px;
-      padding-bottom: 16px !important;
-    }
-  }
 }
 
 /*--------------

--- a/src/definitions/inloco/layout.less
+++ b/src/definitions/inloco/layout.less
@@ -202,6 +202,45 @@
       }
     }
   }
+
+  .inloco-layout__sidebar-submenu.ui.dropdown.item > .menu {
+    background: transparent !important;
+    padding: 0 0 0 12px;
+    margin-left: 0 !important;
+    box-shadow: none;
+  }
+
+  .inloco-layout__sidebar-submenu.ui.dropdown.item > .menu > .header,
+  .inloco-layout__sidebar-submenu.ui.dropdown.item > .menu > .item {
+    background: #fff !important;
+    border-radius: 0px;
+    border-left: 1px solid rgba(0, 0, 0, 0.08);
+    border-right: 1px solid rgba(0, 0, 0, 0.08);
+  }
+
+  .inloco-layout__sidebar-submenu.ui.dropdown.item > .menu > .header {
+    padding: 16px 12px 12px !important;
+    opacity: 1;
+    color: rgba(@gray800, 0.4);
+    border-top: 1px solid rgba(0, 0, 0, 0.08);
+    border-top-left-radius: 3px;
+    border-top-right-radius: 3px;
+  }
+
+  .inloco-layout__sidebar-submenu.ui.dropdown.item > .menu > .item {
+    padding: 8px 12px !important;
+
+    &:hover {
+      background: @n50 !important;
+    }
+
+    &:last-child {
+      border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+      border-bottom-left-radius: 3px;
+      border-bottom-right-radius: 3px;
+      padding-bottom: 16px !important;
+    }
+  }
 }
 
 /*--------------

--- a/src/site/modules/popup.overrides
+++ b/src/site/modules/popup.overrides
@@ -13,3 +13,7 @@
     right: -3px;
   }
 }
+
+.inloco-layout__sidebar-submenu .menu.transition.visible {
+  margin-left: 0 !important;
+}

--- a/src/site/modules/popup.overrides
+++ b/src/site/modules/popup.overrides
@@ -13,7 +13,3 @@
     right: -3px;
   }
 }
-
-.inloco-layout__sidebar-submenu .menu.transition.visible {
-  margin-left: 0 !important;
-}

--- a/src/site/modules/popup.overrides
+++ b/src/site/modules/popup.overrides
@@ -14,6 +14,6 @@
   }
 }
 
-.inloco-popup--hidden.ui.popup {
-  display: none !important;
+.inloco-layout__sidebar-submenu .menu.transition.visible {
+  margin-left: 0 !important;
 }


### PR DESCRIPTION
Bruno sugeriu que todos os items com submenu abram-se através de um "hover", não mais de um click como anteriormente.

A tarefa foi um pouco mais complicada do que o imaginado de início, e envolveu bastante CSS para resolver um problema: o submenu está a alguns pixels de distância do seu trigger (onde o mouseEnter/mouseLeave é aplicado), se eu não fizesse o ajuste com o CSS sempre que o usuário tentasse passar do trigger para o submenu haveria um mouseLeaver e o submenu seria fechado.

![2019-03-12 11 32 42](https://user-images.githubusercontent.com/4473734/54208403-9ff8cf80-44ba-11e9-8b96-e3a4cbfd2c57.gif)
