### PR TITLE
feature(layout): increase contrast

### DIFF
--- a/src/definitions/inloco/layout.less
+++ b/src/definitions/inloco/layout.less
@@ -17,7 +17,7 @@
 
 .inloco-layout {
   display: flex;
-  background-color: @gray50;
+  background-color: #f6f8f9;
   flex-direction: column;
   height: 100vh;
   overflow-y: auto;
@@ -34,7 +34,7 @@
 @sidebarWidth: 65px;
 
 .inloco-layout__sidebar.ui.vertical.menu {
-  border-right: 1px solid fade(@n600, 7%);
+  border-right: 1px solid fade(@n600, 15%);
   border-radius: 0;
   box-shadow: 2px 0 3px -2px fade(@n600, 5%);
   display: flex;
@@ -212,12 +212,13 @@
   align-items: center;
   border: none;
   border-radius: 0;
-  box-shadow: 0 2px 3px -2px fade(@n600, 5%);
+  box-shadow: 0 2px 3px -2px fade(@n600, 15%);
   flex-shrink: 0;
   grid-area: topbar;
   height: 64px;
   margin: 0 0 0 64px;
   order: 0;
+  background: #f6f8f9;
 
   .menu.right {
     .ui.item.dropdown {

--- a/src/site/elements/button.variables
+++ b/src/site/elements/button.variables
@@ -25,27 +25,27 @@
 @downBackgroundColor: fade(@n600, 20%);
 
 @focusColor: inherit;
-@focusBoxShadow: inset 0 0 0px 1px rgba(62, 73, 101, .2) !important;
+@focusBoxShadow: inset 0 0 0px 1px fade(@n600, 20%) !important;
 
 @coloredBoxShadow: none;
 
 @medium: 14px;
 
-@backgroundColor: rgba(62, 73, 101, .08);
+@backgroundColor: fade(@n600, .08);
 @backgroundImage: none;
 @coloredBackgroundImage: none;
 @basicColoredBorderSize: 0;
 @borderBoxShadow: 0px 0px 0px 0px transparent;
-@hoverBackgroundColor: rgba(62, 73, 101, .12);
+@hoverBackgroundColor: fade(@n600, 12%);
 
-@secondaryColor: rgba(62,73,101,0.08);
-@secondaryColorHover: rgba(62,73,101,0.12);
-@secondaryColorFocus: rgba(62,73,101,0.12);
-@secondaryColorDown:  rgba(62,73,101,0.2);
+@secondaryColor: fade(@n600,0.08);
+@secondaryColorHover: fade(@n600, 12%);
+@secondaryColorFocus: fade(@n600, 12%);
+@secondaryColorDown:  fade(@n600, 2%);
 
-@basicHoverBackground: rgba(62,73,101,0.08);
-@basicFocusBackground: rgba(62,73,101,0.08);
-@basicDownBackground: rgba(62,73,101,0.12);
+@basicHoverBackground: fade(@n600, 8%);
+@basicFocusBackground: fade(@n600, 8%);
+@basicDownBackground: fade(@n600, 12%);
 
 @iconButtonOpacity: unset;
 @iconFontSize: 20px;

--- a/src/site/globals/site.variables
+++ b/src/site/globals/site.variables
@@ -126,8 +126,8 @@
 --------------------*/
 
 /* Used on inputs, textarea etc */
-@focusedFormBorderColor: rgba(62, 73, 101, .25);
-@inputPlaceholderFocusColor: rgba(62, 73, 101, .25);
+@focusedFormBorderColor: fade(@n600, 25%);
+@inputPlaceholderFocusColor: fade(@n600, 25%);
 @focusedFormMutedBorderColor: rgba(34, 36, 38, .35);
 
 /*-------------------


### PR DESCRIPTION
Aumenta o contraste entre os menus e o conteúdo da página, [conforme pedido neste card](https://trello.com/c/vGJyApsP/403-ajustes-de-ui-no-menu#comment-5c87c6b1cb5efa50b529c78c).

Além disso substituo alguns códigos rgb por seu equivalente, `@n600`

![image](https://user-images.githubusercontent.com/4473734/54283252-64263e80-457c-11e9-96f5-3329142206ba.png)

