### PR TITLE
Switch the order of the buttons in WizardFooterBasicControls

### DIFF
--- a/components/Wizard/Footer/BasicControls.js
+++ b/components/Wizard/Footer/BasicControls.js
@@ -63,14 +63,6 @@ class WizardFooterBasicControls extends Component {
             type: 'button'
           }
         })}
-        {(currentStep > 0 || showBackOnFirstStep) &&
-          Button.create(buttons[Buttons.PREVIOUS], {
-            autoGenerateKey: false,
-            defaultProps: {
-              onClick: this.handlePrevious,
-              type: 'button'
-            }
-          })}
         {showSaveButton &&
           !isLastStep &&
           Button.create(buttons[Buttons.SAVE], {
@@ -78,6 +70,14 @@ class WizardFooterBasicControls extends Component {
             defaultProps: {
               onClick: onSave,
               type: 'submit'
+            }
+          })}
+        {(currentStep > 0 || showBackOnFirstStep) &&
+          Button.create(buttons[Buttons.PREVIOUS], {
+            autoGenerateKey: false,
+            defaultProps: {
+              onClick: this.handlePrevious,
+              type: 'button'
             }
           })}
         {!isLastStep &&

--- a/components/Wizard/Footer/__tests__/WizardFooterBasicControls.test.js
+++ b/components/Wizard/Footer/__tests__/WizardFooterBasicControls.test.js
@@ -78,7 +78,7 @@ describe('WizardFooterBasicControls', () => {
     it('should call the "onSave" prop when the "save" button is clicked', () => {
       const onSave = jest.fn()
       const wrapper = buildWrapper({ showSaveButton: true, onSave })
-      const button = wrapper.find(Button).at(2)
+      const button = wrapper.find(Button).at(1)
       button.simulate('click')
       expect(onSave).toHaveBeenCalled()
     })

--- a/components/Wizard/Footer/__tests__/__snapshots__/WizardFooterBasicControls.test.js.snap
+++ b/components/Wizard/Footer/__tests__/__snapshots__/WizardFooterBasicControls.test.js.snap
@@ -90,16 +90,16 @@ exports[`WizardFooterBasicControls when the "showSaveButton" prop is set to "tru
   />
   <Button
     as="button"
+    content="Save"
+    role="button"
+    type="submit"
+  />
+  <Button
+    as="button"
     content="Previous"
     onClick={[Function]}
     role="button"
     type="button"
-  />
-  <Button
-    as="button"
-    content="Save"
-    role="button"
-    type="submit"
   />
   <Button
     as="button"


### PR DESCRIPTION
This order of this buttons wasn't on the prototype when I created them, but now Bruno defined that the `Save` button should  be before the `Back` button.

**Before**
<img width="334" alt="Screen Shot 2019-03-13 at 2 06 36 PM" src="https://user-images.githubusercontent.com/5216049/54299277-5501b980-4599-11e9-88b9-032c7d2c6275.png">

**After**
<img width="352" alt="Screen Shot 2019-03-13 at 2 06 16 PM" src="https://user-images.githubusercontent.com/5216049/54299286-5a5f0400-4599-11e9-8832-a7190e4dbe6b.png">
