### PR TITLE
 Style the dropdown menu

### DIFF
--- a/src/site/collections/form.overrides
+++ b/src/site/collections/form.overrides
@@ -41,6 +41,15 @@
   }
 }
 
+.ui.form .field.error .ui.dropdown .text {
+  background-color: transparent;
+  color: @textColor;
+
+  &.default {
+    color: fade(@textColor, 40%);
+  }
+}
+
 .inloco-form-validator__message {
   align-items: center;
   color: @red;

--- a/src/site/collections/form.variables
+++ b/src/site/collections/form.variables
@@ -36,3 +36,7 @@
 @inputErrorFocusBorder: @formErrorBorder;
 
 @inputErrorFocusBoxShadow: 0 0 0px 1px fade(@red, 50%);
+
+@dropdownErrorSelectedBackground: fade(@n600, 6%);
+@dropdownErrorActiveBackground: @dropdownErrorSelectedBackground;
+@dropdownErrorHoverBackground: fade(@n600, 4%);

--- a/src/site/modules/dropdown.variables
+++ b/src/site/modules/dropdown.variables
@@ -9,6 +9,15 @@
 @borderRadius: 3px;
 @borderColor: fade(@n600, 25%);
 @textCursorSpacing: 0;
+
+@itemColor: @textColor;
+
+@hoveredItemColor: @textColor;
+@hoveredItemBackground: fade(@n600, 4%);
+
+@selectedColor: @textColor;
+@selectedBackground: fade(@n600, 6%);
+
 @selectionIconOpacity: unset;
 @selectionIconVerticalPadding: 6px;
 @selectionIconHorizontalPadding: 12px;

--- a/stories/FormValidator/validation.stories.js
+++ b/stories/FormValidator/validation.stories.js
@@ -1,9 +1,9 @@
 import React, { Component } from 'react'
 import { storiesOf } from '@storybook/react'
 
-import { Button, Checkbox, Form, Input } from '../../components'
+import { Button, Checkbox, Dropdown, Form, Input } from '../../components'
 
-const validate = ({ firstName, lastName, website, terms }) => {
+const validate = ({ firstName, lastName, website, jobType, terms }) => {
   const errors = {}
   if (!firstName) {
     errors.firstName = 'Required field.'
@@ -16,6 +16,9 @@ const validate = ({ firstName, lastName, website, terms }) => {
       'Required field. ',
       'The website must have at least one dot (".").'
     ]
+  }
+  if (!jobType) {
+    errors.jobType = 'Required field.'
   }
   if (!terms) {
     errors.terms = 'Required field.'
@@ -56,6 +59,21 @@ class ExampleForm extends Component {
             label="https://"
             name="website"
             onChange={this.handleChange}
+          />
+        </Form.ValidatedField>
+        <Form.ValidatedField message={messages.jobType}>
+          <label>Job Type</label>
+          <Dropdown
+            placeholder="Job Type"
+            name="jobType"
+            onChange={this.handleChange}
+            options={[
+              { text: 'Company Employee', value: 1 },
+              { text: 'Freelancer', value: 2 }
+            ]}
+            selectOnBlur={false}
+            selectOnNavigation={false}
+            selection
           />
         </Form.ValidatedField>
         <Form.ValidatedField message={messages.terms}>


### PR DESCRIPTION
I was just going to fix the style of dropdowns when they have an error, but in the process I noticed that the dropdown menu was using wrong colors. Fixed those as well, but the difference is not visible enough with screenshots (Bruno himself hadn't noticed this yet), so I'll just show the screenshots for the error styling:

**Before**
<img width="1190" alt="Screen Shot 2019-03-18 at 10 42 29 AM" src="https://user-images.githubusercontent.com/5216049/54534293-cca16100-496a-11e9-918e-e70594c8a7b7.png">


**After**
<img width="1189" alt="Screen Shot 2019-03-18 at 10 42 03 AM" src="https://user-images.githubusercontent.com/5216049/54534296-d034e800-496a-11e9-80bb-105796c04878.png">

Summary of the changes: Bruno just wanted the dropdown box to be black, the menu should stay the same way as when there are no errors.
