### PR TITLE
fix(sidebar-submenu): add margin-bottom

### DIFF
--- a/src/definitions/inloco/layout.less
+++ b/src/definitions/inloco/layout.less
@@ -144,6 +144,10 @@
 }
 
 .inloco-layout__sidebar.ui.vertical.menu {
+  .inloco-layout__sidebar-submenu {
+    margin-bottom: 8px;
+  }
+
   .inloco-layout__sidebar-submenu-accordion {
     flex-wrap: wrap;
     height: auto;

--- a/stories/Layout/index.stories.js
+++ b/stories/Layout/index.stories.js
@@ -25,6 +25,7 @@ const StoryLayout = ({ noBreadcrumb, withWarning, ...otherProps }) => (
         <Layout.SidebarItem content="Analytics" icon="timeline" />
         <Layout.SidebarItem content="Lists" icon="view list" />
       </Layout.SidebarSubmenu>
+      <Layout.SidebarItem content="Apps" icon="smartphone" />
       <Divider />
       <Layout.SidebarFooter>
         <Layout.SidebarSubmenu content="Help" icon="help">


### PR DESCRIPTION
Antes, por não haver uma margin-bottom definida desde o início os itens com submenu davam essa sambada quando expandia-se o menu.

![2019-03-27 08 55 42](https://user-images.githubusercontent.com/4473734/55074093-217d5f80-506e-11e9-82c4-ebfaffc9f7eb.gif)
