### PR TITLE
Enhancement: Layout

### DIFF
--- a/components/Layout/Main/index.js
+++ b/components/Layout/Main/index.js
@@ -12,9 +12,9 @@ class Main extends Component {
     const { children, className, ...otherProps } = this.props
     const classes = cx('inloco-layout__main', className)
     return (
-      <div className={classes} {...otherProps}>
+      <main className={classes} {...otherProps}>
         {children}
-      </div>
+      </main>
     )
   }
 }

--- a/src/definitions/inloco/layout.less
+++ b/src/definitions/inloco/layout.less
@@ -290,7 +290,7 @@
 @headerHeight: 64px;
 
 .inloco-layout__main {
-  margin-top: 12px;
+  margin: 12px 0 0 96px;
   grid-area: main;
   order: 2;
 
@@ -308,7 +308,7 @@
 }
 
 .inloco-layout__main-content {
-  margin: 12px 32px 0 96px;
+  margin: 12px 32px 0 0;
 }
 
 /*--------------
@@ -319,7 +319,7 @@
   display: grid;
   height: @headerHeight;
   justify-content: space-between;
-  padding: 8px 32px 8px 96px;
+  padding: 8px 32px 8px 0;
   position: relative;
 
   .ui.breadcrumb {


### PR DESCRIPTION
1. `Layout.Main` agora renderiza a tag `<main />` em vez de `<div />`.
2. `Layout.Main` é responsável por adicionar `margin-left`, em vez de delegar esta responsabilidade para seus filhos: `Layout.Header` e `Layout.MainContent`.

Visualmente, o componente continua da mesma forma:

![image](https://user-images.githubusercontent.com/1139664/55442531-6e3ccb00-5585-11e9-8587-db01f3b581dc.png)
