### PR TITLE
enhancement(LayoutSidebar): Sometimes (loading time), it makes sense …

### DIFF
--- a/components/Layout/Sidebar/index.js
+++ b/components/Layout/Sidebar/index.js
@@ -8,7 +8,7 @@ import SidebarContext from './SidebarContext'
 
 class Sidebar extends Component {
   static propTypes = {
-    children: PropTypes.node.isRequired,
+    children: PropTypes.node,
     headerTitle: PropTypes.string
   }
 


### PR DESCRIPTION
…to show the Sidebar without children.

Cenário:

No Ads, quando estamos montando o sidebar, cada URL tem o ID da organização. Ex:

```
http://app.inlocoads.com/68bcc717-424c-4f3b-9c02-ab6856415ef7/campaigns
```

Enquanto estamos requisitando os dados da organização no carregamento da página, a gente renderiza o Sidebar sem nenhum children (link).

![2019-04-04 19 09 13](https://user-images.githubusercontent.com/1139664/55591920-46786f00-570d-11e9-921d-ca4b3470f932.gif)


