### PR TITLE
fix(Layout): When there is no sidebar, we should adjust the margin of…

### DIFF
--- a/src/definitions/inloco/layout.less
+++ b/src/definitions/inloco/layout.less
@@ -409,16 +409,8 @@
     margin-left: 0;
   }
 
-  .inloco-layout__main-content {
+  .inloco-layout__main {
     margin-left: 32px;
-  }
-
-  .inloco-layout__header {
-    padding-left: 32px;
-
-    .ui.breadcrumb {
-      left: 32px;
-    }
   }
 }
 


### PR DESCRIPTION
… the <main> element

This bug is a side-effect from my last commit where I moved the margin left to the `<Main>`.

It happens when there is no sidebar.

Thanks to @mairatma who found it.

Before:
![image](https://user-images.githubusercontent.com/1139664/55642838-fd292d80-57a7-11e9-8b2e-ec5b6f5e9b75.png)

After:
![image](https://user-images.githubusercontent.com/1139664/55642848-087c5900-57a8-11e9-8ff0-38ad0d0db937.png)


