### PR TITLE
fix(LayoutMain): Fix layout main, when the header gets sticky

### DIFF
--- a/src/definitions/inloco/layout.less
+++ b/src/definitions/inloco/layout.less
@@ -290,7 +290,7 @@
 @headerHeight: 64px;
 
 .inloco-layout__main {
-  margin: 12px 0 0 96px;
+  margin: 12px 0 0 64px;
   grid-area: main;
   order: 2;
 
@@ -308,7 +308,7 @@
 }
 
 .inloco-layout__main-content {
-  margin: 12px 32px 0 0;
+  margin: 12px 32px 0 32px;
 }
 
 /*--------------
@@ -319,7 +319,7 @@
   display: grid;
   height: @headerHeight;
   justify-content: space-between;
-  padding: 8px 32px 8px 0;
+  padding: 8px 32px 8px 32px;
   position: relative;
 
   .ui.breadcrumb {
@@ -410,7 +410,7 @@
   }
 
   .inloco-layout__main {
-    margin-left: 32px;
+    margin-left: 0;
   }
 }
 


### PR DESCRIPTION
Havia um bug ainda (espero que seja o último).

Quando o Header ficava sticky, o background dele já começava 32px de distancia do sidebar.

![image](https://user-images.githubusercontent.com/1139664/55654832-d62f2380-57c8-11e9-93e7-6f2f2c91ea05.png)

Reajustei agora. O `main` é responsável por dar 64px de margin, e os filhos do main são responsávels de dar seus margin/paddings laterais (32px).

![image](https://user-images.githubusercontent.com/1139664/55654988-3c1bab00-57c9-11e9-8f79-c9a2852a3bc1.png)

