### PR TITLE
fix(accordion): remove negative margin from accordion's icon

### DIFF
--- a/src/site/modules/accordion.overrides
+++ b/src/site/modules/accordion.overrides
@@ -7,7 +7,6 @@
   align-items: center;
   font-family: Icons;
   justify-content: center;
-  margin-right: -7px;
 
   &:before {
     content: '\E313';


### PR DESCRIPTION
A alteração que eu havia feito estava causando alguns [erros bizarros](https://bitbucket.org/ubeedev/engage-js/pull-requests/1633/fix-devicehealthcheck-resultsdetailed/diff)