### PR TITLE
fix(submenu): closes it when the event target is an dropdown option or is inside one

### DIFF
--- a/components/Layout/Sidebar/Submenu/Dropdown.js
+++ b/components/Layout/Sidebar/Submenu/Dropdown.js
@@ -101,11 +101,12 @@ class SidebarSubmenuDropdown extends Component {
 
   handleOutsideClick = event => {
     const { current: wrapper } = this.wrapperRef
+    const optionClass = 'inloco-layout__sidebar-item'
     const isAnOutsideClick = wrapper && !wrapper.contains(event.target)
-    const isAnOptionClick =
-      !isAnOutsideClick &&
-      event.target.classList.contains('inloco-layout__sidebar-item')
-    const isAMenuTriggerClick = !isAnOutsideClick && !isAnOptionClick
+    const isTargetAnOption =
+      event.target.classList.contains(optionClass) ||
+      event.target.parentElement.classList.contains(optionClass)
+    const isAMenuTriggerClick = !isAnOutsideClick && !isTargetAnOption
 
     if (isAMenuTriggerClick) {
       return this.handleClick()


### PR DESCRIPTION
Algumas vezes, ao clicar na opção, ele poderia acabar não fechando pois acabava chamando dois eventos de click, e um deles sinalizava que era para fecha (você clicou de fato na opção) e outro sinalizava que não (você clicou em algo dentro da opção, mas não na opção).

Agora isso está corrigido e funcionando 100%.